### PR TITLE
add windows controller mvp + refactor

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,20 +30,17 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v4
-
-    # selecting a toolchain either by action or manual `rustup` calls should happen
-    # before the plugin, as the cache uses the current rustc version as its cache key
-    - run: rustup toolchain install nightly 
-
-    - uses: Swatinem/rust-cache@v2
-      with:
-        prefix-key: "clippy"
-
-    - name: Run Clippy
-      run: cargo clippy --all-targets --all-features
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            components: clippy
+            override: true
+      - uses: actions-rs/clippy-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          args: --all-features
 
   format:
     name: format

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,17 +30,20 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions-rs/toolchain@v1
-        with:
-            toolchain: nightly
-            components: clippy
-            override: true
-      - uses: actions-rs/clippy-check@v1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          args: --all-features
+    - uses: actions/checkout@v4
+
+    # selecting a toolchain either by action or manual `rustup` calls should happen
+    # before the plugin, as the cache uses the current rustc version as its cache key
+    - run: rustup toolchain install nightly 
+
+    - uses: Swatinem/rust-cache@v2
+      with:
+        prefix-key: "clippy"
+
+    - name: Run Clippy
+      run: cargo clippy --all-targets --all-features
 
   format:
     name: format

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1183,7 +1183,7 @@ name = "joystick"
 version = "0.1.0"
 dependencies = [
  "evdev",
- "tokio",
+ "vigem-client",
 ]
 
 [[package]]
@@ -2260,15 +2260,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2518,26 +2509,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
 dependencies = [
  "backtrace",
- "bytes",
  "libc",
  "mio 1.0.2",
- "parking_lot",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
- "tokio-macros",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "tokio-macros"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.77",
 ]
 
 [[package]]
@@ -2639,6 +2615,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vigem-client"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b857e6f99efe1e1eb1e4dfb035de8ae7ec8ec56bd1928edcbd7c6e4427634d52"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "walkdir"

--- a/crates/joystick/Cargo.toml
+++ b/crates/joystick/Cargo.toml
@@ -4,5 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+
+[target.'cfg(windows)'.dependencies]
+vigem-client = "0.1.4"
+
+[target.'cfg(unix)'.dependencies]
 evdev = { git = "https://github.com/emberian/evdev", rev = "150df0d055290ea7db5e4e1ec9889d629232e9d8", features = ["tokio"]}
-tokio = { version = "1.37.0", features = ["full"] }

--- a/crates/joystick/src/lib.rs
+++ b/crates/joystick/src/lib.rs
@@ -1,4 +1,6 @@
+#[cfg(target_os = "linux")]
 #[cfg_attr(target_os = "linux", path = "linux.rs")]
-pub mod linux;
+pub mod joystick;
+#[cfg(target_os = "windows")]
 #[cfg_attr(windows, path = "windows.rs")]
-pub mod windows;
+pub mod joystick;

--- a/crates/joystick/src/linux.rs
+++ b/crates/joystick/src/linux.rs
@@ -1,4 +1,3 @@
-#[cfg_attr(target_os = "linux")]
 use evdev::{
     uinput::{VirtualDevice, VirtualDeviceBuilder},
     AbsInfo, AbsoluteAxisCode, AttributeSet, EventType, InputEvent, KeyCode, UinputAbsSetup,

--- a/crates/joystick/src/linux.rs
+++ b/crates/joystick/src/linux.rs
@@ -1,3 +1,4 @@
+#[cfg_attr(target_os = "linux")]
 use evdev::{
     uinput::{VirtualDevice, VirtualDeviceBuilder},
     AbsInfo, AbsoluteAxisCode, AttributeSet, EventType, InputEvent, KeyCode, UinputAbsSetup,
@@ -23,7 +24,6 @@ struct JoystickEvent {
 
 pub struct Joystick {
     device: Arc<Mutex<VirtualDevice>>,
-    name: String,
     keys: AttributeSet<KeyCode>,
     events: Vec<JoystickEvent>,
     instant: Instant,
@@ -67,7 +67,6 @@ impl Default for Joystick {
         Joystick {
             events: vec![],
             device: Arc::new(Mutex::new(device)),
-            name: name.to_string(),
             instant: Instant::now(),
             keys,
         }
@@ -77,10 +76,6 @@ impl Default for Joystick {
 impl Joystick {
     pub fn new(&self) -> Self {
         Joystick::default()
-    }
-
-    pub fn name(&self) -> &str {
-        &self.name
     }
 
     pub fn tap_a(&mut self) {

--- a/crates/joystick/src/linux.rs
+++ b/crates/joystick/src/linux.rs
@@ -141,7 +141,7 @@ impl Joystick {
         self.device.lock().unwrap().emit(&keys).unwrap();
     }
 
-    pub fn tap(&mut self, button: KeyCode) {
+    fn tap(&mut self, button: KeyCode) {
         // send in press and release
         let time = self.instant.elapsed();
         let release_duration = Duration::from_millis(TAP_DURATION);

--- a/crates/joystick/src/linux.rs
+++ b/crates/joystick/src/linux.rs
@@ -185,21 +185,30 @@ impl Joystick {
 
 #[cfg(test)]
 mod tests {
-    use crate::Joystick;
+    use crate::joystick::Joystick;
     use std::thread::sleep;
     use std::time::{Duration, Instant};
 
     #[test]
     fn test_event_system() -> std::io::Result<()> {
+        sleep(Duration::from_millis(1000));
         let mut joystick: Joystick = Joystick::default();
+        joystick.tap_dpad_up();
+        sleep(Duration::from_millis(500));
+        joystick.tap_dpad_down();
+        sleep(Duration::from_millis(500));
+        joystick.tap_dpad_left();
+        sleep(Duration::from_millis(500));
+        joystick.tap_dpad_right();
+        sleep(Duration::from_millis(500));
         joystick.tap_a();
-        sleep(Duration::from_millis(200));
+        sleep(Duration::from_millis(500));
         joystick.tap_b();
-        sleep(Duration::from_millis(200));
+        sleep(Duration::from_millis(500));
         joystick.tap_x();
-        sleep(Duration::from_millis(200));
+        sleep(Duration::from_millis(500));
         joystick.tap_y();
-        sleep(Duration::from_millis(200));
+        sleep(Duration::from_millis(500));
         joystick.instant = Instant::now();
         assert!(!joystick.events.is_empty());
 

--- a/crates/joystick/src/windows.rs
+++ b/crates/joystick/src/windows.rs
@@ -156,3 +156,56 @@ impl Joystick {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::joystick::Joystick;
+    use std::thread::sleep;
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn test_event_system() -> std::io::Result<()> {
+        sleep(Duration::from_millis(1000));
+        let mut joystick: Joystick = Joystick::default();
+        joystick.tap_dpad_up();
+        sleep(Duration::from_millis(500));
+        joystick.tap_dpad_down();
+        sleep(Duration::from_millis(500));
+        joystick.tap_dpad_left();
+        sleep(Duration::from_millis(500));
+        joystick.tap_dpad_right();
+        sleep(Duration::from_millis(500));
+        joystick.tap_a();
+        sleep(Duration::from_millis(500));
+        joystick.tap_b();
+        sleep(Duration::from_millis(500));
+        joystick.tap_x();
+        sleep(Duration::from_millis(500));
+        joystick.tap_y();
+        sleep(Duration::from_millis(500));
+        joystick.instant = Instant::now();
+        assert!(!joystick.events.is_empty());
+
+        while !joystick.events.is_empty() {
+            joystick.run();
+        }
+
+        assert!(joystick.events.is_empty());
+        Result::Ok(())
+    }
+
+    #[test]
+    fn ensure_instants_reset() -> std::io::Result<()> {
+        let mut joystick: Joystick = Joystick::default();
+        joystick.tap_a();
+        assert!(!joystick.events.is_empty());
+
+        while !joystick.events.is_empty() {
+            joystick.run();
+        }
+
+        assert!(joystick.instant < Instant::now() + Duration::from_secs(1));
+        assert!(joystick.events.is_empty());
+        Result::Ok(())
+    }
+}

--- a/crates/joystick/src/windows.rs
+++ b/crates/joystick/src/windows.rs
@@ -113,7 +113,7 @@ impl Joystick {
         self.gamepad.buttons = vigem_client::XButtons!();
     }
 
-    pub fn tap(&mut self, button: u16) {
+    fn tap(&mut self, button: u16) {
         // send in press and release
         let time = self.instant.elapsed();
         let release_duration = Duration::from_millis(TAP_DURATION);

--- a/crates/joystick/src/windows.rs
+++ b/crates/joystick/src/windows.rs
@@ -1,5 +1,5 @@
 use std::time::{Duration, Instant};
-use vigem_client::{Client, XButtons, Xbox360Wired, TargetId, XGamepad};
+use vigem_client::{Client, TargetId, XButtons, XGamepad, Xbox360Wired};
 
 static TAP_DURATION: u64 = 50;
 
@@ -139,11 +139,11 @@ impl Joystick {
                     match event.action {
                         KeyAction::Release => {
                             // bitwise AND NOT (removes the button from the bitflags)
-                            self.button_mask = self.button_mask & !event.key
+                            self.button_mask &= !event.key
                         }
                         KeyAction::Press => {
                             // bitwise OR (adds the button to the bitflags)
-                            self.button_mask = self.button_mask | event.key
+                            self.button_mask |= event.key
                         }
                     };
                     self.gamepad.buttons.raw = self.button_mask;


### PR DESCRIPTION
Adds an mvp for windows joystick support - completely untested, but should serve as a solid basis.

When in use, the main things that need to be tested is the use of bitwise operations for the joystick mask. This sort of dodges the way they use macros, but should work for our use case.

There may be a (likely) case where we want to use the same clock for the sequencer and the joystick, so a small refactor or additional code would need to be added for handling time outside the library. Added a note in the tracking issue.

Additional Tasks in #7 will be completed at a later date.