### PR TITLE
Refactored duplicate code in MemoryManagers using generics.

### DIFF
--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,14 +1,28 @@
 pub mod player_party_manager;
 pub mod title_sequence_manager;
 
-use crate::memory::player_party_manager::PlayerPartyManager;
-use crate::memory::title_sequence_manager::TitleSequenceManager;
 use crate::state::StateContext;
+
+use memory::memory_manager::unity::{UnityMemoryManagement, UnityMemoryManager};
+use memory::process::Error;
+use player_party_manager::PlayerPartyManagerData;
+use title_sequence_manager::TitleSequenceManagerData;
+
+pub trait MemoryManagerUpdate {
+    fn update(&mut self, ctx: &StateContext, manager: &mut UnityMemoryManager)
+        -> Result<(), Error>;
+}
+
+pub struct MemoryManager<T: MemoryManagerUpdate> {
+    pub name: String,
+    pub manager: UnityMemoryManager,
+    pub data: T,
+}
 
 #[derive(Default)]
 pub struct MemoryManagers {
-    pub title_sequence_manager: TitleSequenceManager,
-    pub player_party_manager: PlayerPartyManager,
+    pub title_sequence_manager: MemoryManager<TitleSequenceManagerData>,
+    pub player_party_manager: MemoryManager<PlayerPartyManagerData>,
 }
 
 impl MemoryManagers {
@@ -23,18 +37,42 @@ impl MemoryManagers {
     }
 }
 
-pub trait MemoryManager {
+impl<T: MemoryManagerUpdate> MemoryManager<T> {
+    fn ready_for_updates(&mut self, _ctx: &StateContext) -> bool {
+        if let Some(class) = self.manager.singleton {
+            if class.class == 0 {
+                return false;
+            }
+
+            return true;
+        }
+        false
+    }
+
+    fn update_manager(&mut self, ctx: &StateContext) {
+        if let Some(process) = &ctx.process {
+            if let Some(module) = &ctx.module {
+                if let Some(image) = &ctx.image {
+                    self.manager.update(process, module, image, &self.name);
+                }
+            }
+        }
+    }
+
+    fn update_memory(&mut self, ctx: &StateContext) {
+        match self.data.update(ctx, &mut self.manager) {
+            Ok(_) => (),
+            Err(_error) => {
+                println!("RESETTING");
+                self.manager.reset()
+            }
+        }
+    }
+
     fn update(&mut self, ctx: &StateContext) {
         self.update_manager(ctx);
         if self.ready_for_updates(ctx) {
             self.update_memory(ctx);
         }
     }
-
-    fn ready_for_updates(&mut self, _state: &StateContext) -> bool {
-        true
-    }
-
-    fn update_manager(&mut self, state: &StateContext);
-    fn update_memory(&mut self, state: &StateContext);
 }

--- a/src/memory/player_party_manager.rs
+++ b/src/memory/player_party_manager.rs
@@ -1,16 +1,10 @@
-use crate::memory::MemoryManager;
+use crate::memory::{MemoryManager, MemoryManagerUpdate};
 use crate::state::StateContext;
-use memory::memory_manager::unity::*;
+use memory::memory_manager::unity::UnityMemoryManager;
 use memory::process::Error;
 use vec3_rs::Vector3;
 
-pub struct PlayerPartyManager {
-    pub name: String,
-    pub manager: UnityMemoryManager,
-    pub data: PlayerPartyManagerData,
-}
-
-impl Default for PlayerPartyManager {
+impl Default for MemoryManager<PlayerPartyManagerData> {
     fn default() -> Self {
         let manager = Self {
             name: "PlayerPartyManager".to_string(),
@@ -24,42 +18,13 @@ impl Default for PlayerPartyManager {
     }
 }
 
-impl MemoryManager for PlayerPartyManager {
-    fn ready_for_updates(&mut self, _ctx: &StateContext) -> bool {
-        if let Some(class) = self.manager.singleton {
-            if class.class == 0 {
-                return false;
-            }
-            return true;
-        }
-        true
-    }
-
-    fn update_manager(&mut self, ctx: &StateContext) {
-        if let Some(process) = &ctx.process {
-            if let Some(module) = &ctx.module {
-                if let Some(image) = &ctx.image {
-                    self.manager.update(process, module, image, &self.name);
-                }
-            }
-        }
-    }
-
-    fn update_memory(&mut self, ctx: &StateContext) {
-        match self.data.update(ctx, &mut self.manager) {
-            Ok(_) => (),
-            Err(_error) => self.manager.reset(),
-        }
-    }
-}
-
 #[derive(Default, Debug)]
 pub struct PlayerPartyManagerData {
     pub position: Vector3<f32>,
 }
 
-impl PlayerPartyManagerData {
-    pub fn update(
+impl MemoryManagerUpdate for PlayerPartyManagerData {
+    fn update(
         &mut self,
         ctx: &StateContext,
         manager: &mut UnityMemoryManager,
@@ -69,7 +34,9 @@ impl PlayerPartyManagerData {
             Err(error) => Err(error),
         }
     }
+}
 
+impl PlayerPartyManagerData {
     // This function updates the users position for nav helper
     // Unfortunately because some classes here dont have true objects
     // this by using follow_fields since while we are going up the chain

--- a/src/memory/title_sequence_manager.rs
+++ b/src/memory/title_sequence_manager.rs
@@ -1,15 +1,9 @@
-use crate::memory::MemoryManager;
+use crate::memory::{MemoryManager, MemoryManagerUpdate};
 use crate::state::StateContext;
-use memory::memory_manager::unity::*;
+use memory::memory_manager::unity::UnityMemoryManager;
 use memory::process::Error;
 
-pub struct TitleSequenceManager {
-    pub name: String,
-    pub manager: UnityMemoryManager,
-    pub data: TitleSequenceManagerData,
-}
-
-impl Default for TitleSequenceManager {
+impl Default for MemoryManager<TitleSequenceManagerData> {
     fn default() -> Self {
         let manager = Self {
             name: "TitleSequenceManager".to_string(),
@@ -23,46 +17,13 @@ impl Default for TitleSequenceManager {
     }
 }
 
-impl MemoryManager for TitleSequenceManager {
-    fn ready_for_updates(&mut self, _ctx: &StateContext) -> bool {
-        if let Some(class) = self.manager.singleton {
-            if class.class == 0 {
-                return false;
-            }
-
-            return true;
-        }
-        false
-    }
-
-    fn update_manager(&mut self, ctx: &StateContext) {
-        if let Some(process) = &ctx.process {
-            if let Some(module) = &ctx.module {
-                if let Some(image) = &ctx.image {
-                    self.manager.update(process, module, image, &self.name);
-                }
-            }
-        }
-    }
-
-    fn update_memory(&mut self, ctx: &StateContext) {
-        match self.data.update(ctx, &mut self.manager) {
-            Ok(_) => (),
-            Err(_error) => {
-                println!("RESETTING");
-                self.manager.reset()
-            }
-        }
-    }
-}
-
 #[derive(Default, Debug)]
 pub struct TitleSequenceManagerData {
     pub title_menu: TitleMenu,
 }
 
-impl TitleSequenceManagerData {
-    pub fn update(
+impl MemoryManagerUpdate for TitleSequenceManagerData {
+    fn update(
         &mut self,
         ctx: &StateContext,
         manager: &mut UnityMemoryManager,
@@ -72,7 +33,9 @@ impl TitleSequenceManagerData {
             Err(error) => Err(error),
         }
     }
+}
 
+impl TitleSequenceManagerData {
     pub fn update_title_menu(
         &mut self,
         ctx: &StateContext,


### PR DESCRIPTION
A suggestion on how code could be refactored to reduce duplication. If you had other plans for the shared methods (`ready_for_updates`, `update_manager`, `update_memory`), maybe hold off on it.