### PR TITLE
feat: create joystick interface and partially implement

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,6 +412,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cast_trait"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4f8d981c476baadf74cd52897866a1d279d3e14e2d5e2d9af045210e0ae6128"
+
+[[package]]
 name = "cc"
 version = "1.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1183,6 +1189,7 @@ name = "joystick"
 version = "0.1.0"
 dependencies = [
  "evdev",
+ "vec2",
  "vigem-client",
 ]
 
@@ -2591,6 +2598,27 @@ dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+]
+
+[[package]]
+name = "vec2"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a54c8415531b580fac54552a697128f338ea26bb790b88a5c6351e401b4cbb3f"
+dependencies = [
+ "cast_trait",
+ "num-traits",
+ "vec3",
+]
+
+[[package]]
+name = "vec3"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ad952cfbcbc36c86769e13cf9ce2203b6ce9271fa54a03f259a35d1930449e1"
+dependencies = [
+ "cast_trait",
+ "num-traits",
 ]
 
 [[package]]

--- a/crates/joystick/Cargo.toml
+++ b/crates/joystick/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+num = "0.4.3"
 
 [target.'cfg(windows)'.dependencies]
 vigem-client = "0.1.4"

--- a/crates/joystick/Cargo.toml
+++ b/crates/joystick/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-num = "0.4.3"
+vec2 = "0.2.1"
 
 [target.'cfg(windows)'.dependencies]
 vigem-client = "0.1.4"

--- a/crates/joystick/src/common.rs
+++ b/crates/joystick/src/common.rs
@@ -1,9 +1,3 @@
-pub static TAP_DURATION: u64 = 50;
-
-pub enum KeyAction {
-    Press,
-    Release,
-}
 
 pub enum Button {
     A,

--- a/crates/joystick/src/common.rs
+++ b/crates/joystick/src/common.rs
@@ -1,6 +1,13 @@
 use evdev::KeyCode;
 use std::time::Duration;
 
+pub static TAP_DURATION: u64 = 50;
+
+pub enum KeyAction {
+    Press,
+    Release,
+}
+
 pub trait JoystickInterface {
     fn press_a(&mut self);
     fn press_b(&mut self);

--- a/crates/joystick/src/common.rs
+++ b/crates/joystick/src/common.rs
@@ -1,0 +1,68 @@
+use evdev::KeyCode;
+use std::time::Duration;
+
+pub trait JoystickInterface {
+    fn press_a(&mut self);
+    fn press_b(&mut self);
+    fn press_x(&mut self);
+    fn press_y(&mut self);
+    fn press_lt(&mut self);
+    fn press_rt(&mut self);
+    fn press_lt2(&mut self);
+    fn press_rt2(&mut self);
+    fn press_select(&mut self);
+    fn press_start(&mut self);
+    fn press_dpad_up(&mut self);
+    fn press_dpad_down(&mut self);
+    fn press_dpad_left(&mut self);
+    fn press_dpad_right(&mut self);
+
+    fn release_a(&mut self);
+    fn release_b(&mut self);
+    fn release_x(&mut self);
+    fn release_y(&mut self);
+    fn release_lt(&mut self);
+    fn release_rt(&mut self);
+    fn release_lt2(&mut self);
+    fn release_rt2(&mut self);
+    fn release_select(&mut self);
+    fn release_start(&mut self);
+    fn release_dpad_up(&mut self);
+    fn release_dpad_down(&mut self);
+    fn release_dpad_left(&mut self);
+    fn release_dpad_right(&mut self);
+
+    fn tap_a(&mut self);
+    fn tap_b(&mut self);
+    fn tap_x(&mut self);
+    fn tap_y(&mut self);
+    fn tap_lt(&mut self);
+    fn tap_rt(&mut self);
+    fn tap_lt2(&mut self);
+    fn tap_rt2(&mut self);
+    fn tap_select(&mut self);
+    fn tap_start(&mut self);
+    fn tap_dpad_up(&mut self);
+    fn tap_dpad_down(&mut self);
+    fn tap_dpad_left(&mut self);
+    fn tap_dpad_right(&mut self);
+    fn release_all(&mut self);
+    fn run(&mut self);
+
+    #[cfg(target_os = "linux")]
+    fn tap(&mut self, button: KeyCode);
+    #[cfg(target_os = "linux")]
+    fn press(&mut self, button: KeyCode);
+    #[cfg(target_os = "linux")]
+    fn release(&mut self, button: KeyCode);
+    #[cfg(target_os = "linux")]
+    fn release_later(&mut self, button: KeyCode, duration: Duration);
+    #[cfg(target_os = "windows")]
+    fn tap(&mut self, button: u16);
+    #[cfg(target_os = "windows")]
+    fn press(&mut self, button: u16);
+    #[cfg(target_os = "windows")]
+    fn release(&mut self, button: u16);
+    #[cfg(target_os = "windows")]
+    fn release_later(&mut self, button: u16, duration: Duration);
+}

--- a/crates/joystick/src/common.rs
+++ b/crates/joystick/src/common.rs
@@ -1,4 +1,3 @@
-
 pub enum Button {
     A,
     B,
@@ -13,11 +12,13 @@ pub enum Button {
     UP,
     DOWN,
     LEFT,
-    RIGHT
+    RIGHT,
 }
 
 pub trait JoystickInterface {
     fn release_all(&mut self);
     fn press(&mut self, button: Button);
     fn release(&mut self, button: Button);
+    // [x, y], where the values range from -1 to 1
+    fn set_joy(&mut self, dir: [f32; 2]);
 }

--- a/crates/joystick/src/common.rs
+++ b/crates/joystick/src/common.rs
@@ -1,6 +1,3 @@
-use evdev::KeyCode;
-use std::time::Duration;
-
 pub static TAP_DURATION: u64 = 50;
 
 pub enum KeyAction {
@@ -8,68 +5,25 @@ pub enum KeyAction {
     Release,
 }
 
+pub enum Button {
+    A,
+    B,
+    X,
+    Y,
+    LT,
+    RT,
+    LT2,
+    RT2,
+    SELECT,
+    START,
+    UP,
+    DOWN,
+    LEFT,
+    RIGHT
+}
+
 pub trait JoystickInterface {
-    fn press_a(&mut self);
-    fn press_b(&mut self);
-    fn press_x(&mut self);
-    fn press_y(&mut self);
-    fn press_lt(&mut self);
-    fn press_rt(&mut self);
-    fn press_lt2(&mut self);
-    fn press_rt2(&mut self);
-    fn press_select(&mut self);
-    fn press_start(&mut self);
-    fn press_dpad_up(&mut self);
-    fn press_dpad_down(&mut self);
-    fn press_dpad_left(&mut self);
-    fn press_dpad_right(&mut self);
-
-    fn release_a(&mut self);
-    fn release_b(&mut self);
-    fn release_x(&mut self);
-    fn release_y(&mut self);
-    fn release_lt(&mut self);
-    fn release_rt(&mut self);
-    fn release_lt2(&mut self);
-    fn release_rt2(&mut self);
-    fn release_select(&mut self);
-    fn release_start(&mut self);
-    fn release_dpad_up(&mut self);
-    fn release_dpad_down(&mut self);
-    fn release_dpad_left(&mut self);
-    fn release_dpad_right(&mut self);
-
-    fn tap_a(&mut self);
-    fn tap_b(&mut self);
-    fn tap_x(&mut self);
-    fn tap_y(&mut self);
-    fn tap_lt(&mut self);
-    fn tap_rt(&mut self);
-    fn tap_lt2(&mut self);
-    fn tap_rt2(&mut self);
-    fn tap_select(&mut self);
-    fn tap_start(&mut self);
-    fn tap_dpad_up(&mut self);
-    fn tap_dpad_down(&mut self);
-    fn tap_dpad_left(&mut self);
-    fn tap_dpad_right(&mut self);
     fn release_all(&mut self);
-    fn run(&mut self);
-
-    #[cfg(target_os = "linux")]
-    fn tap(&mut self, button: KeyCode);
-    #[cfg(target_os = "linux")]
-    fn press(&mut self, button: KeyCode);
-    #[cfg(target_os = "linux")]
-    fn release(&mut self, button: KeyCode);
-    #[cfg(target_os = "linux")]
-    fn release_later(&mut self, button: KeyCode, duration: Duration);
-    #[cfg(target_os = "windows")]
-    fn tap(&mut self, button: u16);
-    #[cfg(target_os = "windows")]
-    fn press(&mut self, button: u16);
-    #[cfg(target_os = "windows")]
-    fn release(&mut self, button: u16);
-    #[cfg(target_os = "windows")]
-    fn release_later(&mut self, button: u16, duration: Duration);
+    fn press(&mut self, button: Button);
+    fn release(&mut self, button: Button);
 }

--- a/crates/joystick/src/lib.rs
+++ b/crates/joystick/src/lib.rs
@@ -4,5 +4,5 @@ pub mod common;
 #[cfg_attr(target_os = "linux", path = "linux.rs")]
 pub mod joystick;
 #[cfg(target_os = "windows")]
-#[cfg_attr(windows, path = "windows.rs")]
+#[cfg_attr(target_os = "windows", path = "windows.rs")]
 pub mod joystick;

--- a/crates/joystick/src/lib.rs
+++ b/crates/joystick/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod common;
+
 #[cfg(target_os = "linux")]
 #[cfg_attr(target_os = "linux", path = "linux.rs")]
 pub mod joystick;

--- a/crates/joystick/src/linux.rs
+++ b/crates/joystick/src/linux.rs
@@ -6,7 +6,7 @@ use evdev::{
 use std::sync::Arc;
 use std::sync::Mutex;
 
-use crate::common::{JoystickInterface, Button, KeyAction};
+use crate::common::{Button, JoystickInterface, KeyAction};
 
 pub struct Joystick {
     device: Arc<Mutex<VirtualDevice>>,
@@ -104,10 +104,10 @@ impl Default for Joystick {
 
 // To visually run these tests, use:
 // `cargo test -- --test-threads 1`
-// then focus https://hardwaretester.com/gamepad 
+// then focus https://hardwaretester.com/gamepad
 #[cfg(test)]
 mod tests {
-    use crate::common::{JoystickInterface, Button};
+    use crate::common::{Button, JoystickInterface};
     use crate::joystick::Joystick;
     use std::thread::sleep;
     use std::time::Duration;

--- a/crates/joystick/src/linux.rs
+++ b/crates/joystick/src/linux.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
+use crate::common::JoystickInterface;
 static TAP_DURATION: u64 = 50;
 
 enum KeyAction {
@@ -26,6 +27,245 @@ pub struct Joystick {
     keys: AttributeSet<KeyCode>,
     events: Vec<JoystickEvent>,
     instant: Instant,
+}
+
+impl JoystickInterface for Joystick {
+    fn press_a(&mut self) {
+        self.press(KeyCode::BTN_EAST)
+    }
+
+    fn press_b(&mut self) {
+        self.press(KeyCode::BTN_SOUTH)
+    }
+
+    fn press_x(&mut self) {
+        self.press(KeyCode::BTN_NORTH)
+    }
+
+    fn press_y(&mut self) {
+        self.press(KeyCode::BTN_WEST)
+    }
+
+    fn press_lt(&mut self) {
+        self.press(KeyCode::BTN_TL)
+    }
+
+    fn press_rt(&mut self) {
+        self.press(KeyCode::BTN_TR)
+    }
+
+    fn press_lt2(&mut self) {
+        self.press(KeyCode::BTN_TL2)
+    }
+
+    fn press_rt2(&mut self) {
+        self.press(KeyCode::BTN_TR2)
+    }
+
+    fn press_select(&mut self) {
+        self.press(KeyCode::BTN_SELECT)
+    }
+
+    fn press_start(&mut self) {
+        self.press(KeyCode::BTN_START)
+    }
+
+    fn press_dpad_up(&mut self) {
+        self.press(KeyCode::BTN_DPAD_UP)
+    }
+
+    fn press_dpad_down(&mut self) {
+        self.press(KeyCode::BTN_DPAD_DOWN)
+    }
+
+    fn press_dpad_left(&mut self) {
+        self.press(KeyCode::BTN_DPAD_LEFT)
+    }
+
+    fn press_dpad_right(&mut self) {
+        self.press(KeyCode::BTN_DPAD_RIGHT)
+    }
+
+    fn release_a(&mut self) {
+        self.release(KeyCode::BTN_EAST)
+    }
+
+    fn release_b(&mut self) {
+        self.release(KeyCode::BTN_SOUTH)
+    }
+
+    fn release_x(&mut self) {
+        self.release(KeyCode::BTN_NORTH)
+    }
+
+    fn release_y(&mut self) {
+        self.release(KeyCode::BTN_WEST)
+    }
+
+    fn release_lt(&mut self) {
+        self.release(KeyCode::BTN_TL)
+    }
+
+    fn release_rt(&mut self) {
+        self.release(KeyCode::BTN_TR)
+    }
+
+    fn release_lt2(&mut self) {
+        self.release(KeyCode::BTN_TL2)
+    }
+
+    fn release_rt2(&mut self) {
+        self.release(KeyCode::BTN_TR2)
+    }
+
+    fn release_select(&mut self) {
+        self.release(KeyCode::BTN_SELECT)
+    }
+
+    fn release_start(&mut self) {
+        self.release(KeyCode::BTN_START)
+    }
+
+    fn release_dpad_up(&mut self) {
+        self.release(KeyCode::BTN_DPAD_UP)
+    }
+
+    fn release_dpad_down(&mut self) {
+        self.release(KeyCode::BTN_DPAD_DOWN)
+    }
+
+    fn release_dpad_left(&mut self) {
+        self.release(KeyCode::BTN_DPAD_LEFT)
+    }
+
+    fn release_dpad_right(&mut self) {
+        self.release(KeyCode::BTN_DPAD_RIGHT)
+    }
+
+    fn tap_a(&mut self) {
+        self.tap(KeyCode::BTN_EAST)
+    }
+
+    fn tap_b(&mut self) {
+        self.tap(KeyCode::BTN_SOUTH)
+    }
+
+    fn tap_x(&mut self) {
+        self.tap(KeyCode::BTN_NORTH)
+    }
+
+    fn tap_y(&mut self) {
+        self.tap(KeyCode::BTN_WEST)
+    }
+
+    fn tap_lt(&mut self) {
+        self.tap(KeyCode::BTN_TL)
+    }
+
+    fn tap_rt(&mut self) {
+        self.tap(KeyCode::BTN_TR)
+    }
+
+    fn tap_lt2(&mut self) {
+        self.tap(KeyCode::BTN_TL2)
+    }
+
+    fn tap_rt2(&mut self) {
+        self.tap(KeyCode::BTN_TR2)
+    }
+
+    fn tap_select(&mut self) {
+        self.tap(KeyCode::BTN_SELECT)
+    }
+
+    fn tap_start(&mut self) {
+        self.tap(KeyCode::BTN_START)
+    }
+
+    fn tap_dpad_up(&mut self) {
+        self.tap(KeyCode::BTN_DPAD_UP)
+    }
+
+    fn tap_dpad_down(&mut self) {
+        self.tap(KeyCode::BTN_DPAD_DOWN)
+    }
+
+    fn tap_dpad_left(&mut self) {
+        self.tap(KeyCode::BTN_DPAD_LEFT)
+    }
+
+    fn tap_dpad_right(&mut self) {
+        self.tap(KeyCode::BTN_DPAD_RIGHT)
+    }
+
+    fn release_all(&mut self) {
+        let mut keys = vec![];
+        for key in &self.keys {
+            keys.push(InputEvent::new(EventType::KEY.0, key.code(), 0));
+        }
+        self.device.lock().unwrap().emit(&keys).unwrap();
+    }
+
+    fn run(&mut self) {
+        if !self.events.is_empty() {
+            let timer_time = self.instant.elapsed();
+
+            for event in &self.events {
+                if event.duration <= timer_time {
+                    let action = match event.action {
+                        KeyAction::Release => 0,
+                        KeyAction::Press => 1,
+                    };
+                    let event = InputEvent::new(event.event_type.0, event.key.code(), action);
+
+                    self.device.lock().unwrap().emit(&[event]).unwrap();
+                }
+            }
+            self.events.retain(|event| event.duration > timer_time);
+        } else {
+            self.instant = Instant::now();
+        }
+    }
+
+    fn press(&mut self, button: KeyCode) {
+        let time = self.instant.elapsed();
+
+        self.events.push(JoystickEvent {
+            key: button,
+            event_type: EventType::KEY,
+            duration: time,
+            action: KeyAction::Press,
+        });
+    }
+
+    fn release(&mut self, button: KeyCode) {
+        let time = self.instant.elapsed();
+
+        self.events.push(JoystickEvent {
+            key: button,
+            event_type: EventType::KEY,
+            duration: time,
+            action: KeyAction::Release,
+        });
+    }
+
+    fn release_later(&mut self, button: KeyCode, duration: Duration) {
+        let time = self.instant.elapsed();
+
+        self.events.push(JoystickEvent {
+            key: button,
+            event_type: EventType::KEY,
+            duration: time + duration,
+            action: KeyAction::Release,
+        });
+    }
+
+    fn tap(&mut self, button: KeyCode) {
+        // send in press and release
+        let release_duration = Duration::from_millis(TAP_DURATION);
+        self.press(button);
+        self.release_later(button, release_duration);
+    }
 }
 
 impl Default for Joystick {
@@ -72,118 +312,9 @@ impl Default for Joystick {
     }
 }
 
-impl Joystick {
-    pub fn new(&self) -> Self {
-        Joystick::default()
-    }
-
-    pub fn tap_a(&mut self) {
-        self.tap(KeyCode::BTN_EAST)
-    }
-
-    pub fn tap_b(&mut self) {
-        self.tap(KeyCode::BTN_SOUTH)
-    }
-
-    pub fn tap_x(&mut self) {
-        self.tap(KeyCode::BTN_NORTH)
-    }
-
-    pub fn tap_y(&mut self) {
-        self.tap(KeyCode::BTN_WEST)
-    }
-
-    pub fn tap_lt(&mut self) {
-        self.tap(KeyCode::BTN_TL)
-    }
-
-    pub fn tap_rt(&mut self) {
-        self.tap(KeyCode::BTN_TR)
-    }
-
-    pub fn tap_lt2(&mut self) {
-        self.tap(KeyCode::BTN_TL2)
-    }
-
-    pub fn tap_rt2(&mut self) {
-        self.tap(KeyCode::BTN_TR2)
-    }
-
-    pub fn tap_select(&mut self) {
-        self.tap(KeyCode::BTN_SELECT)
-    }
-
-    pub fn tap_start(&mut self) {
-        self.tap(KeyCode::BTN_START)
-    }
-
-    pub fn tap_dpad_up(&mut self) {
-        self.tap(KeyCode::BTN_DPAD_UP)
-    }
-
-    pub fn tap_dpad_down(&mut self) {
-        self.tap(KeyCode::BTN_DPAD_DOWN)
-    }
-
-    pub fn tap_dpad_left(&mut self) {
-        self.tap(KeyCode::BTN_DPAD_LEFT)
-    }
-
-    pub fn tap_dpad_right(&mut self) {
-        self.tap(KeyCode::BTN_DPAD_RIGHT)
-    }
-
-    pub fn release_all(&mut self) {
-        let mut keys = vec![];
-        for key in &self.keys {
-            keys.push(InputEvent::new(EventType::KEY.0, key.code(), 0));
-        }
-        self.device.lock().unwrap().emit(&keys).unwrap();
-    }
-
-    fn tap(&mut self, button: KeyCode) {
-        // send in press and release
-        let time = self.instant.elapsed();
-        let release_duration = Duration::from_millis(TAP_DURATION);
-
-        self.events.push(JoystickEvent {
-            key: button,
-            event_type: EventType::KEY,
-            duration: time,
-            action: KeyAction::Press,
-        });
-        self.events.push(JoystickEvent {
-            key: button,
-            event_type: EventType::KEY,
-            duration: time + release_duration,
-            action: KeyAction::Release,
-        });
-    }
-
-    pub fn run(&mut self) {
-        if !self.events.is_empty() {
-            let timer_time = self.instant.elapsed();
-
-            for event in &self.events {
-                if event.duration <= timer_time {
-                    let action = match event.action {
-                        KeyAction::Release => 0,
-                        KeyAction::Press => 1,
-                    };
-                    let event = InputEvent::new(event.event_type.0, event.key.code(), action);
-
-                    self.device.lock().unwrap().emit(&[event]).unwrap();
-                }
-            }
-            self.events.retain(|event| event.duration > timer_time);
-        } else {
-            self.instant = Instant::now();
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use crate::common::JoystickInterface;
     use crate::joystick::Joystick;
     use std::thread::sleep;
     use std::time::{Duration, Instant};
@@ -207,6 +338,14 @@ mod tests {
         joystick.tap_x();
         sleep(Duration::from_millis(500));
         joystick.tap_y();
+        sleep(Duration::from_millis(500));
+        joystick.tap_lt();
+        sleep(Duration::from_millis(500));
+        joystick.tap_rt();
+        sleep(Duration::from_millis(500));
+        joystick.tap_lt2();
+        sleep(Duration::from_millis(500));
+        joystick.tap_rt2();
         sleep(Duration::from_millis(500));
         joystick.instant = Instant::now();
         assert!(!joystick.events.is_empty());

--- a/crates/joystick/src/linux.rs
+++ b/crates/joystick/src/linux.rs
@@ -7,13 +7,7 @@ use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
-use crate::common::JoystickInterface;
-static TAP_DURATION: u64 = 50;
-
-enum KeyAction {
-    Press,
-    Release,
-}
+use crate::common::{JoystickInterface, KeyAction, TAP_DURATION};
 
 struct JoystickEvent {
     key: KeyCode,

--- a/crates/joystick/src/linux.rs
+++ b/crates/joystick/src/linux.rs
@@ -56,7 +56,7 @@ impl JoystickInterface for Joystick {
         let x_code = AbsoluteAxisCode::ABS_X.0;
         let y_code = AbsoluteAxisCode::ABS_Y.0;
         let abs_x = (clamped_dir[0] * i16::MAX as f32) as i16;
-        let abs_y = (clamped_dir[1] * i16::MAX as f32) as i16;
+        let abs_y = -(clamped_dir[1] * i16::MAX as f32) as i16;
 
         let x_event = *AbsoluteAxisEvent::new(AbsoluteAxisCode(x_code), abs_x.into());
         let y_event = *AbsoluteAxisEvent::new(AbsoluteAxisCode(y_code), abs_y.into());

--- a/crates/joystick/src/windows.rs
+++ b/crates/joystick/src/windows.rs
@@ -2,13 +2,7 @@ use std::time::{Duration, Instant};
 use vigem_client::{Client, TargetId, XButtons, XGamepad, Xbox360Wired};
 
 use crate::common::JoystickInterface;
-
-static TAP_DURATION: u64 = 50;
-
-enum KeyAction {
-    Press,
-    Release,
-}
+use crate::common::{JoystickInterface, KeyAction, TAP_DURATION};
 
 pub struct Joystick {
     device: Xbox360Wired<Client>, // may need to be Arc<Mutex>>
@@ -289,25 +283,6 @@ impl JoystickInterface for Joystick {
         let release_duration = Duration::from_millis(TAP_DURATION);
         self.press(button);
         self.release_later(button, release_duration);
-    }
-}
-
-impl Joystick {
-    fn tap(&mut self, button: u16) {
-        // send in press and release
-        let time = self.instant.elapsed();
-        let release_duration = Duration::from_millis(TAP_DURATION);
-
-        self.events.push(JoystickEvent {
-            key: button,
-            duration: time,
-            action: KeyAction::Press,
-        });
-        self.events.push(JoystickEvent {
-            key: button,
-            duration: time + release_duration,
-            action: KeyAction::Release,
-        });
     }
 }
 

--- a/crates/joystick/src/windows.rs
+++ b/crates/joystick/src/windows.rs
@@ -1,21 +1,10 @@
-use std::time::{Duration, Instant};
 use vigem_client::{Client, TargetId, XButtons, XGamepad, Xbox360Wired};
 
-use crate::common::JoystickInterface;
-use crate::common::{JoystickInterface, KeyAction, TAP_DURATION};
+use crate::common::{JoystickInterface, Button};
 
 pub struct Joystick {
     device: Xbox360Wired<Client>, // may need to be Arc<Mutex>>
     gamepad: vigem_client::XGamepad,
-    events: Vec<JoystickEvent>,
-    button_mask: u16, // current mask for the joystick
-    pub instant: Instant,
-}
-
-struct JoystickEvent {
-    key: u16,
-    duration: Duration,
-    action: KeyAction,
 }
 
 impl Default for Joystick {
@@ -35,260 +24,52 @@ impl Default for Joystick {
 
         Joystick {
             device,
-            events: vec![],
-            button_mask: 0x0,
-            instant: Instant::now(),
             gamepad,
         }
     }
 }
 
-impl JoystickInterface for Joystick {
-    fn press_a(&mut self) {
-        self.press(XButtons::A)
-    }
-
-    fn press_b(&mut self) {
-        self.press(XButtons::B)
-    }
-
-    fn press_x(&mut self) {
-        self.press(XButtons::X)
-    }
-
-    fn press_y(&mut self) {
-        self.press(XButtons::Y)
-    }
-
-    fn press_lt(&mut self) {
-        self.press(XButtons::LB)
-    }
-
-    fn press_rt(&mut self) {
-        self.press(XButtons::RB)
-    }
-
-    // TODO(eein): We dont rear triggers yet
-    fn press_lt2(&mut self) {
-        // self.press(XButtons::LB)
-    }
-
-    fn press_rt2(&mut self) {
-        // self.press(XButtons::RB)
-    }
-
-    fn press_select(&mut self) {
-        self.press(XButtons::BACK)
-    }
-
-    fn press_start(&mut self) {
-        self.press(XButtons::START)
-    }
-
-    fn press_dpad_up(&mut self) {
-        self.press(XButtons::UP)
-    }
-
-    fn press_dpad_down(&mut self) {
-        self.press(XButtons::DOWN)
-    }
-
-    fn press_dpad_left(&mut self) {
-        self.press(XButtons::LEFT)
-    }
-
-    fn press_dpad_right(&mut self) {
-        self.press(XButtons::RIGHT)
-    }
-
-    fn release_a(&mut self) {
-        self.release(XButtons::A)
-    }
-
-    fn release_b(&mut self) {
-        self.release(XButtons::B)
-    }
-
-    fn release_x(&mut self) {
-        self.release(XButtons::X)
-    }
-
-    fn release_y(&mut self) {
-        self.release(XButtons::Y)
-    }
-
-    fn release_lt(&mut self) {
-        self.release(XButtons::LB)
-    }
-
-    fn release_rt(&mut self) {
-        self.release(XButtons::RB)
-    }
-
-    // TODO(eein): We dont rear triggers yet
-    fn release_lt2(&mut self) {
-        // self.release(XButtons::LB)
-    }
-
-    fn release_rt2(&mut self) {
-        // self.release(XButtons::RB)
-    }
-
-    fn release_select(&mut self) {
-        self.release(XButtons::BACK)
-    }
-
-    fn release_start(&mut self) {
-        self.release(XButtons::START)
-    }
-
-    fn release_dpad_up(&mut self) {
-        self.release(XButtons::UP)
-    }
-
-    fn release_dpad_down(&mut self) {
-        self.release(XButtons::DOWN)
-    }
-
-    fn release_dpad_left(&mut self) {
-        self.release(XButtons::LEFT)
-    }
-
-    fn release_dpad_right(&mut self) {
-        self.release(XButtons::RIGHT)
-    }
-
-    fn tap_a(&mut self) {
-        self.tap(XButtons::A)
-    }
-
-    fn tap_b(&mut self) {
-        self.tap(XButtons::B)
-    }
-
-    fn tap_x(&mut self) {
-        self.tap(XButtons::X)
-    }
-
-    fn tap_y(&mut self) {
-        self.tap(XButtons::Y)
-    }
-
-    fn tap_lt(&mut self) {
-        self.tap(XButtons::LB)
-    }
-
-    fn tap_rt(&mut self) {
-        self.tap(XButtons::RB)
-    }
-
-    // TODO(eein): We dont rear triggers yet
-    fn tap_lt2(&mut self) {
-        // self.tap(XButtons::LB)
-    }
-
-    fn tap_rt2(&mut self) {
-        // self.tap(XButtons::RB)
-    }
-
-    fn tap_select(&mut self) {
-        self.tap(XButtons::BACK)
-    }
-
-    fn tap_start(&mut self) {
-        self.tap(XButtons::START)
-    }
-
-    fn tap_dpad_up(&mut self) {
-        self.tap(XButtons::UP)
-    }
-
-    fn tap_dpad_down(&mut self) {
-        self.tap(XButtons::DOWN)
-    }
-
-    fn tap_dpad_left(&mut self) {
-        self.tap(XButtons::LEFT)
-    }
-
-    fn tap_dpad_right(&mut self) {
-        self.tap(XButtons::RIGHT)
-    }
-
-    fn release_all(&mut self) {
-        self.gamepad.buttons = vigem_client::XButtons!();
-    }
-
-    fn run(&mut self) {
-        if !self.events.is_empty() {
-            let timer_time = self.instant.elapsed();
-
-            for event in &self.events {
-                if event.duration <= timer_time {
-                    match event.action {
-                        KeyAction::Release => {
-                            // bitwise AND NOT (removes the button from the bitflags)
-                            self.button_mask &= !event.key
-                        }
-                        KeyAction::Press => {
-                            // bitwise OR (adds the button to the bitflags)
-                            self.button_mask |= event.key
-                        }
-                    };
-                    self.gamepad.buttons.raw = self.button_mask;
-                    let _ = self.device.update(&self.gamepad);
-                }
-            }
-            self.events.retain(|event| event.duration > timer_time);
-        } else {
-            self.instant = Instant::now();
+impl Joystick {
+    fn map_button(button: Button) -> u16 {
+        match button {
+            Button::A => XButtons::A,
+            Button::B => XButtons::B,
+            Button::X => XButtons::X,
+            Button::Y => XButtons::Y,
+            Button::LT => XButtons::LB,
+            Button::LT2 => XButtons::LB, // TODO: Unsure which counts as "Left Shoulder"
+            Button::RT => XButtons::RB,
+            Button::RT2 => XButtons::RB, // TODO: Unsure which counts as "Right Shoulder"
+            Button::SELECT => XButtons::BACK,
+            Button::START => XButtons::START,
+            Button::UP => XButtons::UP,
+            Button::DOWN => XButtons::DOWN,
+            Button::LEFT => XButtons::LEFT,
+            Button::RIGHT => XButtons::RIGHT,
         }
     }
+}
 
-    fn press(&mut self, button: u16) {
-        let time = self.instant.elapsed();
-
-        self.events.push(JoystickEvent {
-            key: button,
-            event_type: EventType::KEY,
-            duration: time,
-            action: KeyAction::Press,
-        });
+impl JoystickInterface for Joystick {
+    fn release_all(&mut self) {
+        self.gamepad.buttons = vigem_client::XButtons!();
+        let _ = self.device.update(&self.gamepad);
     }
-
-    fn release(&mut self, button: u16) {
-        let time = self.instant.elapsed();
-
-        self.events.push(JoystickEvent {
-            key: button,
-            event_type: EventType::KEY,
-            duration: time,
-            action: KeyAction::Release,
-        });
+    fn press(&mut self, button: Button) {
+        let code = Joystick::map_button(button);
+        self.gamepad.buttons.raw |= code;
+        let _ = self.device.update(&self.gamepad);
     }
-
-    fn release_later(&mut self, button: u16, duration: Duration) {
-        let time = self.instant.elapsed();
-
-        self.events.push(JoystickEvent {
-            key: button,
-            event_type: EventType::KEY,
-            duration: time + duration,
-            action: KeyAction::Release,
-        });
-    }
-
-    fn tap(&mut self, button: u16) {
-        // send in press and release
-        let release_duration = Duration::from_millis(TAP_DURATION);
-        self.press(button);
-        self.release_later(button, release_duration);
+    fn release(&mut self, button: Button) {
+        let code = Joystick::map_button(button);
+        self.gamepad.buttons.raw &= !code;
+        let _ = self.device.update(&self.gamepad);
     }
 }
 
 // To visually run these tests, use:
 // `cargo test -- --test-threads 1`
-// then focus https://hardwaretester.com/gamepad 
+// then focus https://hardwaretester.com/gamepad
 #[cfg(test)]
 mod tests {
     use crate::common::{JoystickInterface, Button};
@@ -297,6 +78,7 @@ mod tests {
     use std::time::Duration;
 
     #[test]
+    // TODO(orkaboy): A slight misnomer, since there isn't an event system anymore
     fn test_event_system() -> std::io::Result<()> {
         sleep(Duration::from_millis(2000));
         let mut joystick: Joystick = Joystick::default();

--- a/crates/joystick/src/windows.rs
+++ b/crates/joystick/src/windows.rs
@@ -1,6 +1,8 @@
 use std::time::{Duration, Instant};
 use vigem_client::{Client, TargetId, XButtons, XGamepad, Xbox360Wired};
 
+use crate::common::JoystickInterface;
+
 static TAP_DURATION: u64 = 50;
 
 enum KeyAction {
@@ -47,90 +49,183 @@ impl Default for Joystick {
     }
 }
 
-impl Joystick {
-    pub fn new(&self) -> Self {
-        Joystick::default()
+impl JoystickInterface for Joystick {
+    fn press_a(&mut self) {
+        self.press(XButtons::A)
     }
 
-    pub fn tap_a(&mut self) {
+    fn press_b(&mut self) {
+        self.press(XButtons::B)
+    }
+
+    fn press_x(&mut self) {
+        self.press(XButtons::X)
+    }
+
+    fn press_y(&mut self) {
+        self.press(XButtons::Y)
+    }
+
+    fn press_lt(&mut self) {
+        self.press(XButtons::LB)
+    }
+
+    fn press_rt(&mut self) {
+        self.press(XButtons::RB)
+    }
+
+    // TODO(eein): We dont rear triggers yet
+    fn press_lt2(&mut self) {
+        // self.press(XButtons::LB)
+    }
+
+    fn press_rt2(&mut self) {
+        // self.press(XButtons::RB)
+    }
+
+    fn press_select(&mut self) {
+        self.press(XButtons::BACK)
+    }
+
+    fn press_start(&mut self) {
+        self.press(XButtons::START)
+    }
+
+    fn press_dpad_up(&mut self) {
+        self.press(XButtons::UP)
+    }
+
+    fn press_dpad_down(&mut self) {
+        self.press(XButtons::DOWN)
+    }
+
+    fn press_dpad_left(&mut self) {
+        self.press(XButtons::LEFT)
+    }
+
+    fn press_dpad_right(&mut self) {
+        self.press(XButtons::RIGHT)
+    }
+
+    fn release_a(&mut self) {
+        self.release(XButtons::A)
+    }
+
+    fn release_b(&mut self) {
+        self.release(XButtons::B)
+    }
+
+    fn release_x(&mut self) {
+        self.release(XButtons::X)
+    }
+
+    fn release_y(&mut self) {
+        self.release(XButtons::Y)
+    }
+
+    fn release_lt(&mut self) {
+        self.release(XButtons::LB)
+    }
+
+    fn release_rt(&mut self) {
+        self.release(XButtons::RB)
+    }
+
+    // TODO(eein): We dont rear triggers yet
+    fn release_lt2(&mut self) {
+        // self.release(XButtons::LB)
+    }
+
+    fn release_rt2(&mut self) {
+        // self.release(XButtons::RB)
+    }
+
+    fn release_select(&mut self) {
+        self.release(XButtons::BACK)
+    }
+
+    fn release_start(&mut self) {
+        self.release(XButtons::START)
+    }
+
+    fn release_dpad_up(&mut self) {
+        self.release(XButtons::UP)
+    }
+
+    fn release_dpad_down(&mut self) {
+        self.release(XButtons::DOWN)
+    }
+
+    fn release_dpad_left(&mut self) {
+        self.release(XButtons::LEFT)
+    }
+
+    fn release_dpad_right(&mut self) {
+        self.release(XButtons::RIGHT)
+    }
+
+    fn tap_a(&mut self) {
         self.tap(XButtons::A)
     }
 
-    pub fn tap_b(&mut self) {
+    fn tap_b(&mut self) {
         self.tap(XButtons::B)
     }
 
-    pub fn tap_x(&mut self) {
+    fn tap_x(&mut self) {
         self.tap(XButtons::X)
     }
 
-    pub fn tap_y(&mut self) {
+    fn tap_y(&mut self) {
         self.tap(XButtons::Y)
     }
 
-    pub fn tap_lt(&mut self) {
+    fn tap_lt(&mut self) {
         self.tap(XButtons::LB)
     }
 
-    pub fn tap_rt(&mut self) {
+    fn tap_rt(&mut self) {
         self.tap(XButtons::RB)
     }
 
     // TODO(eein): We dont rear triggers yet
-    pub fn tap_lt2(&mut self) {
+    fn tap_lt2(&mut self) {
         // self.tap(XButtons::LB)
     }
 
-    pub fn tap_rt2(&mut self) {
+    fn tap_rt2(&mut self) {
         // self.tap(XButtons::RB)
     }
 
-    pub fn tap_select(&mut self) {
+    fn tap_select(&mut self) {
         self.tap(XButtons::BACK)
     }
 
-    pub fn tap_start(&mut self) {
+    fn tap_start(&mut self) {
         self.tap(XButtons::START)
     }
 
-    pub fn tap_dpad_up(&mut self) {
+    fn tap_dpad_up(&mut self) {
         self.tap(XButtons::UP)
     }
 
-    pub fn tap_dpad_down(&mut self) {
+    fn tap_dpad_down(&mut self) {
         self.tap(XButtons::DOWN)
     }
 
-    pub fn tap_dpad_left(&mut self) {
+    fn tap_dpad_left(&mut self) {
         self.tap(XButtons::LEFT)
     }
 
-    pub fn tap_dpad_right(&mut self) {
+    fn tap_dpad_right(&mut self) {
         self.tap(XButtons::RIGHT)
     }
 
-    pub fn release_all(&mut self) {
+    fn release_all(&mut self) {
         self.gamepad.buttons = vigem_client::XButtons!();
     }
 
-    fn tap(&mut self, button: u16) {
-        // send in press and release
-        let time = self.instant.elapsed();
-        let release_duration = Duration::from_millis(TAP_DURATION);
-
-        self.events.push(JoystickEvent {
-            key: button,
-            duration: time,
-            action: KeyAction::Press,
-        });
-        self.events.push(JoystickEvent {
-            key: button,
-            duration: time + release_duration,
-            action: KeyAction::Release,
-        });
-    }
-
-    pub fn run(&mut self) {
+    fn run(&mut self) {
         if !self.events.is_empty() {
             let timer_time = self.instant.elapsed();
 
@@ -154,6 +249,65 @@ impl Joystick {
         } else {
             self.instant = Instant::now();
         }
+    }
+
+    fn press(&mut self, button: u16) {
+        let time = self.instant.elapsed();
+
+        self.events.push(JoystickEvent {
+            key: button,
+            event_type: EventType::KEY,
+            duration: time,
+            action: KeyAction::Press,
+        });
+    }
+
+    fn release(&mut self, button: u16) {
+        let time = self.instant.elapsed();
+
+        self.events.push(JoystickEvent {
+            key: button,
+            event_type: EventType::KEY,
+            duration: time,
+            action: KeyAction::Release,
+        });
+    }
+
+    fn release_later(&mut self, button: u16, duration: Duration) {
+        let time = self.instant.elapsed();
+
+        self.events.push(JoystickEvent {
+            key: button,
+            event_type: EventType::KEY,
+            duration: time + duration,
+            action: KeyAction::Release,
+        });
+    }
+
+    fn tap(&mut self, button: u16) {
+        // send in press and release
+        let release_duration = Duration::from_millis(TAP_DURATION);
+        self.press(button);
+        self.release_later(button, release_duration);
+    }
+}
+
+impl Joystick {
+    fn tap(&mut self, button: u16) {
+        // send in press and release
+        let time = self.instant.elapsed();
+        let release_duration = Duration::from_millis(TAP_DURATION);
+
+        self.events.push(JoystickEvent {
+            key: button,
+            duration: time,
+            action: KeyAction::Press,
+        });
+        self.events.push(JoystickEvent {
+            key: button,
+            duration: time + release_duration,
+            action: KeyAction::Release,
+        });
     }
 }
 

--- a/crates/joystick/src/windows.rs
+++ b/crates/joystick/src/windows.rs
@@ -312,6 +312,14 @@ mod tests {
         sleep(Duration::from_millis(500));
         joystick.tap_y();
         sleep(Duration::from_millis(500));
+        joystick.tap_lt();
+        sleep(Duration::from_millis(500));
+        joystick.tap_rt();
+        sleep(Duration::from_millis(500));
+        joystick.tap_lt2();
+        sleep(Duration::from_millis(500));
+        joystick.tap_rt2();
+        sleep(Duration::from_millis(500));
         joystick.instant = Instant::now();
         assert!(!joystick.events.is_empty());
 

--- a/crates/joystick/src/windows.rs
+++ b/crates/joystick/src/windows.rs
@@ -286,63 +286,105 @@ impl JoystickInterface for Joystick {
     }
 }
 
+// To visually run these tests, use:
+// `cargo test -- --test-threads 1`
+// then focus https://hardwaretester.com/gamepad 
 #[cfg(test)]
 mod tests {
+    use crate::common::{JoystickInterface, Button};
     use crate::joystick::Joystick;
     use std::thread::sleep;
-    use std::time::{Duration, Instant};
+    use std::time::Duration;
 
     #[test]
     fn test_event_system() -> std::io::Result<()> {
-        sleep(Duration::from_millis(1000));
+        sleep(Duration::from_millis(2000));
         let mut joystick: Joystick = Joystick::default();
-        joystick.tap_dpad_up();
         sleep(Duration::from_millis(500));
-        joystick.tap_dpad_down();
+        joystick.press(Button::UP);
         sleep(Duration::from_millis(500));
-        joystick.tap_dpad_left();
+        joystick.press(Button::DOWN);
         sleep(Duration::from_millis(500));
-        joystick.tap_dpad_right();
+        joystick.press(Button::LEFT);
         sleep(Duration::from_millis(500));
-        joystick.tap_a();
+        joystick.press(Button::RIGHT);
         sleep(Duration::from_millis(500));
-        joystick.tap_b();
+        joystick.press(Button::A);
         sleep(Duration::from_millis(500));
-        joystick.tap_x();
+        joystick.press(Button::B);
         sleep(Duration::from_millis(500));
-        joystick.tap_y();
+        joystick.press(Button::X);
         sleep(Duration::from_millis(500));
-        joystick.tap_lt();
+        joystick.press(Button::Y);
         sleep(Duration::from_millis(500));
-        joystick.tap_rt();
+        joystick.press(Button::LT);
         sleep(Duration::from_millis(500));
-        joystick.tap_lt2();
+        joystick.press(Button::RT);
         sleep(Duration::from_millis(500));
-        joystick.tap_rt2();
+        joystick.press(Button::LT2);
         sleep(Duration::from_millis(500));
-        joystick.instant = Instant::now();
-        assert!(!joystick.events.is_empty());
+        joystick.press(Button::RT2);
+        sleep(Duration::from_millis(500));
+        joystick.press(Button::SELECT);
+        sleep(Duration::from_millis(500));
+        joystick.press(Button::START);
+        sleep(Duration::from_millis(500));
 
-        while !joystick.events.is_empty() {
-            joystick.run();
-        }
+        joystick.release(Button::UP);
+        sleep(Duration::from_millis(500));
+        joystick.release(Button::DOWN);
+        sleep(Duration::from_millis(500));
+        joystick.release(Button::LEFT);
+        sleep(Duration::from_millis(500));
+        joystick.release(Button::RIGHT);
+        sleep(Duration::from_millis(500));
+        joystick.release(Button::A);
+        sleep(Duration::from_millis(500));
+        joystick.release(Button::B);
+        sleep(Duration::from_millis(500));
+        joystick.release(Button::X);
+        sleep(Duration::from_millis(500));
+        joystick.release(Button::Y);
+        sleep(Duration::from_millis(500));
+        joystick.release(Button::LT);
+        sleep(Duration::from_millis(500));
+        joystick.release(Button::RT);
+        sleep(Duration::from_millis(500));
+        joystick.release(Button::LT2);
+        sleep(Duration::from_millis(500));
+        joystick.release(Button::RT2);
+        sleep(Duration::from_millis(500));
+        joystick.release(Button::SELECT);
+        sleep(Duration::from_millis(500));
+        joystick.release(Button::START);
+        sleep(Duration::from_millis(500));
 
-        assert!(joystick.events.is_empty());
         Result::Ok(())
     }
 
     #[test]
-    fn ensure_instants_reset() -> std::io::Result<()> {
+    fn test_release_all() -> std::io::Result<()> {
+        sleep(Duration::from_millis(2000));
         let mut joystick: Joystick = Joystick::default();
-        joystick.tap_a();
-        assert!(!joystick.events.is_empty());
+        sleep(Duration::from_millis(500));
+        joystick.press(Button::UP);
+        joystick.press(Button::DOWN);
+        joystick.press(Button::LEFT);
+        joystick.press(Button::RIGHT);
+        joystick.press(Button::A);
+        joystick.press(Button::B);
+        joystick.press(Button::X);
+        joystick.press(Button::Y);
+        joystick.press(Button::LT);
+        joystick.press(Button::RT);
+        joystick.press(Button::LT2);
+        joystick.press(Button::RT2);
+        joystick.press(Button::START);
+        joystick.press(Button::SELECT);
+        sleep(Duration::from_millis(1000));
+        joystick.release_all();
+        sleep(Duration::from_millis(500));
 
-        while !joystick.events.is_empty() {
-            joystick.run();
-        }
-
-        assert!(joystick.instant < Instant::now() + Duration::from_secs(1));
-        assert!(joystick.events.is_empty());
         Result::Ok(())
     }
 }

--- a/crates/joystick/src/windows.rs
+++ b/crates/joystick/src/windows.rs
@@ -1,4 +1,4 @@
-use num::clamp;
+use vec2::clamp;
 use vigem_client::{Client, TargetId, XButtons, XGamepad, Xbox360Wired};
 
 use crate::common::{Button, JoystickInterface};
@@ -36,9 +36,9 @@ impl Joystick {
             Button::X => XButtons::X,
             Button::Y => XButtons::Y,
             Button::LT => XButtons::LB,
-            Button::LT2 => XButtons::LB,
+            Button::LT2 => XButtons::LTHUMB,
             Button::RT => XButtons::RB,
-            Button::RT2 => XButtons::RB,
+            Button::RT2 => XButtons::RTHUMB,
             Button::SELECT => XButtons::BACK,
             Button::START => XButtons::START,
             Button::UP => XButtons::UP,
@@ -75,7 +75,8 @@ impl JoystickInterface for Joystick {
         }
     }
     fn set_joy(&mut self, dir: [f32; 2]) {
-        let clamped_dir: [f32; 2] = [clamp(dir[0], -1.0, 1.0), clamp(dir[1], -1.0, 1.0)];
+        let mut clamped_dir = dir;
+        clamp(&mut clamped_dir, &[-1.0, -1.0], &[1.0, 1.0]);
         // Convert from range -1..1 to -32768..32767
         // Negative values are down/left, positive are up/right
         self.gamepad.thumb_lx = (clamped_dir[0] * i16::MAX as f32) as i16;


### PR DESCRIPTION
Feel free to bikeshed this - i'm not sure theres a good way to make the code generic because of the differences between how they interact with the system.

The way it is now, gives alot of options for the user, and lets any new gamepad implementation to work later.

One eventual complaint will be that these functions dont match ALL controllers, but thats probably not something we have to consider at this point.

Windows may or may not work - i'm testing away from home on a linux machine so i'll handle fixes when i get home.

Remaining work before this can be merged
- [x] test press and release functions (one key is fine)\
- [x] implement the new stuff for windows