### PR TITLE
Feat/title sequence manager

### DIFF
--- a/crates/memory/src/game_engine/il2cpp/mod.rs
+++ b/crates/memory/src/game_engine/il2cpp/mod.rs
@@ -1,5 +1,5 @@
 //! Support for attaching to Unity games that are using the IL2CPP backend.
-pub mod unity_items;
+pub mod unity_list;
 
 use crate::pe;
 use crate::process::Error;

--- a/crates/memory/src/game_engine/il2cpp/mod.rs
+++ b/crates/memory/src/game_engine/il2cpp/mod.rs
@@ -1,4 +1,5 @@
 //! Support for attaching to Unity games that are using the IL2CPP backend.
+pub mod unity_items;
 
 use crate::pe;
 use crate::process::Error;

--- a/crates/memory/src/game_engine/il2cpp/unity_items.rs
+++ b/crates/memory/src/game_engine/il2cpp/unity_items.rs
@@ -1,0 +1,42 @@
+use crate::process::{Error, Process};
+
+#[derive(Default, Debug)]
+pub struct UnityItems<T: UnityItem> {
+    pub count: u32,
+    pub items: Vec<T>,
+}
+
+impl<T: UnityItem> UnityItems<T> {
+    pub fn read(process: &Process, addr: u64) -> Result<Self, Error> {
+        const OFFSET: u64 = 0x8;
+        const ITEMS_0_INDEX_BASE: u64 = 0x20;
+
+        let mut items = vec![];
+        let mut fields_base = ITEMS_0_INDEX_BASE;
+
+        let items_ptr = process.read_pointer::<u64>(addr + 0x10)?;
+        let count = process.read_pointer::<u32>(items_ptr + 0x18)?;
+
+        if count == 0 {
+            return Err(Error);
+        }
+
+        for _index in 0..count {
+            let relic_button = T::read(process, fields_base, items_ptr);
+            if relic_button.is_ok() {
+                items.push(relic_button?);
+            }
+
+            fields_base += OFFSET;
+        }
+
+        Ok(Self { count, items })
+    }
+}
+
+/// Trait provided
+pub trait UnityItem {
+    fn read(process: &Process, fields_base: u64, items_ptr: u64) -> Result<Self, Error>
+    where
+        Self: Sized;
+}

--- a/crates/memory/src/game_engine/il2cpp/unity_items.rs
+++ b/crates/memory/src/game_engine/il2cpp/unity_items.rs
@@ -22,9 +22,13 @@ impl<T: UnityItem> UnityItems<T> {
         }
 
         for _index in 0..count {
-            let relic_button = T::read(process, fields_base, items_ptr);
-            if relic_button.is_ok() {
-                items.push(relic_button?);
+            let item_ptr = process.read_pointer::<u64>(items_ptr + fields_base)?;
+            if item_ptr == 0 {
+                return Err(Error);
+            }
+            let item = T::read(process, item_ptr);
+            if item.is_ok() {
+                items.push(item?);
             }
 
             fields_base += OFFSET;
@@ -36,7 +40,7 @@ impl<T: UnityItem> UnityItems<T> {
 
 /// Trait provided
 pub trait UnityItem {
-    fn read(process: &Process, fields_base: u64, items_ptr: u64) -> Result<Self, Error>
+    fn read(process: &Process, item_ptr: u64) -> Result<Self, Error>
     where
         Self: Sized;
 }

--- a/crates/memory/src/game_engine/il2cpp/unity_items.rs
+++ b/crates/memory/src/game_engine/il2cpp/unity_items.rs
@@ -18,11 +18,11 @@ impl<T: UnityItem> UnityItems<T> {
         let count = process.read_pointer::<u32>(items_ptr + 0x18)?;
 
         if items_ptr == 0 {
-            return Err(Error);
+            return Ok(Self {count: 0, items});
         }
 
         if count == 0 {
-            return Err(Error);
+            return Ok(Self {count: 0, items});
         }
 
         for _index in 0..count {

--- a/crates/memory/src/game_engine/il2cpp/unity_items.rs
+++ b/crates/memory/src/game_engine/il2cpp/unity_items.rs
@@ -18,11 +18,11 @@ impl<T: UnityItem> UnityItems<T> {
         let count = process.read_pointer::<u32>(items_ptr + 0x18)?;
 
         if items_ptr == 0 {
-            return Ok(Self {count: 0, items});
+            return Ok(Self { count: 0, items });
         }
 
         if count == 0 {
-            return Ok(Self {count: 0, items});
+            return Ok(Self { count: 0, items });
         }
 
         for _index in 0..count {

--- a/crates/memory/src/game_engine/il2cpp/unity_items.rs
+++ b/crates/memory/src/game_engine/il2cpp/unity_items.rs
@@ -6,17 +6,34 @@ pub struct UnityItems<T: UnityItem> {
     pub items: Vec<T>,
 }
 
+const ITEMS_OFFSET: u64 = 0x10;
+const OFFSET: u64 = 0x8;
+const ITEMS_0_INDEX_BASE: u64 = 0x20;
+const COUNT_OFFSET: u64 = 0x18;
+
+///  UnityItems are laid out in the following format:
+///  ```
+///  field -> ptr
+///    0x10 items -> ptr
+///      0x08 count -> u32
+///      0x20 item[0] -> ptr
+///      0x28 item[1] -> ptr
+///      0x30 item[x] -> ptr
+///  ```
+
 impl<T: UnityItem> UnityItems<T> {
     pub fn read(process: &Process, addr: u64) -> Result<Self, Error> {
-        const OFFSET: u64 = 0x8;
-        const ITEMS_0_INDEX_BASE: u64 = 0x20;
-
         let mut items = vec![];
         let mut fields_base = ITEMS_0_INDEX_BASE;
 
-        let items_ptr = process.read_pointer::<u64>(addr + 0x10)?;
-        let count = process.read_pointer::<u32>(items_ptr + 0x18)?;
+        // The root items pointer
+        let items_ptr = process.read_pointer::<u64>(addr + ITEMS_OFFSET)?;
 
+        // The count in the items pointer
+        let count = process.read_pointer::<u32>(items_ptr + COUNT_OFFSET)?;
+
+        // ensure neither of these is 0, or else just dummy the struct
+        // this is for performance and memory safety
         if items_ptr == 0 {
             return Ok(Self { count: 0, items });
         }
@@ -26,6 +43,7 @@ impl<T: UnityItem> UnityItems<T> {
         }
 
         for _index in 0..count {
+            // the item in the items pointer by offset
             let item_ptr = process.read_pointer::<u64>(items_ptr + fields_base)?;
 
             if item_ptr != 0 {

--- a/crates/memory/src/game_engine/il2cpp/unity_items.rs
+++ b/crates/memory/src/game_engine/il2cpp/unity_items.rs
@@ -23,12 +23,12 @@ impl<T: UnityItem> UnityItems<T> {
 
         for _index in 0..count {
             let item_ptr = process.read_pointer::<u64>(items_ptr + fields_base)?;
-            if item_ptr == 0 {
-                return Err(Error);
-            }
-            let item = T::read(process, item_ptr);
-            if item.is_ok() {
-                items.push(item?);
+
+            if item_ptr != 0 {
+                let item = T::read(process, item_ptr);
+                if item.is_ok() {
+                    items.push(item?);
+                }
             }
 
             fields_base += OFFSET;

--- a/crates/memory/src/game_engine/il2cpp/unity_items.rs
+++ b/crates/memory/src/game_engine/il2cpp/unity_items.rs
@@ -17,6 +17,10 @@ impl<T: UnityItem> UnityItems<T> {
         let items_ptr = process.read_pointer::<u64>(addr + 0x10)?;
         let count = process.read_pointer::<u32>(items_ptr + 0x18)?;
 
+        if items_ptr == 0 {
+            return Err(Error);
+        }
+
         if count == 0 {
             return Err(Error);
         }

--- a/crates/memory/src/game_engine/il2cpp/unity_list.rs
+++ b/crates/memory/src/game_engine/il2cpp/unity_list.rs
@@ -1,7 +1,7 @@
 use crate::process::{Error, Process};
 
 #[derive(Default, Debug)]
-pub struct UnityItems<T: UnityItem> {
+pub struct UnityList<T: UnityListItem> {
     pub count: u32,
     pub items: Vec<T>,
 }
@@ -21,7 +21,7 @@ const COUNT_OFFSET: u64 = 0x18;
 ///      0x30 item[x] -> ptr
 ///  ```
 
-impl<T: UnityItem> UnityItems<T> {
+impl<T: UnityListItem> UnityList<T> {
     pub fn read(process: &Process, addr: u64) -> Result<Self, Error> {
         let mut items = vec![];
         let mut fields_base = ITEMS_0_INDEX_BASE;
@@ -61,7 +61,7 @@ impl<T: UnityItem> UnityItems<T> {
 }
 
 /// Trait provided
-pub trait UnityItem {
+pub trait UnityListItem {
     fn read(process: &Process, item_ptr: u64) -> Result<Self, Error>
     where
         Self: Sized;

--- a/crates/memory/src/game_engine/il2cpp/unity_list.rs
+++ b/crates/memory/src/game_engine/il2cpp/unity_list.rs
@@ -1,7 +1,7 @@
 use crate::process::{Error, Process};
 
 #[derive(Default, Debug)]
-pub struct UnityList<T: UnityListItem> {
+pub struct UnityList<T: UnityItem> {
     pub count: u32,
     pub items: Vec<T>,
 }
@@ -21,7 +21,7 @@ const COUNT_OFFSET: u64 = 0x18;
 ///      0x30 item[x] -> ptr
 ///  ```
 
-impl<T: UnityListItem> UnityList<T> {
+impl<T: UnityItem> UnityList<T> {
     pub fn read(process: &Process, addr: u64) -> Result<Self, Error> {
         let mut items = vec![];
         let mut fields_base = ITEMS_0_INDEX_BASE;
@@ -61,7 +61,7 @@ impl<T: UnityListItem> UnityList<T> {
 }
 
 /// Trait provided
-pub trait UnityListItem {
+pub trait UnityItem {
     fn read(process: &Process, item_ptr: u64) -> Result<Self, Error>
     where
         Self: Sized;

--- a/crates/memory/src/memory_manager/unity.rs
+++ b/crates/memory/src/memory_manager/unity.rs
@@ -11,11 +11,7 @@ pub struct UnityMemoryManager {
 }
 impl UnityMemoryManager {
     pub fn reset(&mut self) {
-        self.class = None;
-        self.parent = None;
-        self.instance = None;
-        self.singleton = None;
-        self.static_table = None;
+        *self = Self::default();
     }
 }
 

--- a/src/gui/helpers/title_helper.rs
+++ b/src/gui/helpers/title_helper.rs
@@ -22,5 +22,9 @@ impl GuiHelper for TitleHelper {
             "Pressed Start: {:?}",
             managers.title_sequence_manager.data.pressed_start
         ));
+        ui.label(format!(
+            "Load Save Done: {:?}",
+            managers.title_sequence_manager.data.load_save_done
+        ));
     }
 }

--- a/src/gui/helpers/title_helper.rs
+++ b/src/gui/helpers/title_helper.rs
@@ -15,8 +15,12 @@ impl TitleHelper {
 impl GuiHelper for TitleHelper {
     fn draw(&mut self, managers: &MemoryManagers, ui: &mut egui::Ui, _tab: &mut String) {
         ui.label(format!(
-            "Menu Item Selected {:?}",
+            "Menu Item Selected: {:?}",
             managers.title_sequence_manager.data.title_menu.selected
+        ));
+        ui.label(format!(
+            "Pressed Start: {:?}",
+            managers.title_sequence_manager.data.pressed_start
         ));
     }
 }

--- a/src/gui/helpers/title_helper.rs
+++ b/src/gui/helpers/title_helper.rs
@@ -12,6 +12,14 @@ impl TitleHelper {
     }
 }
 
+fn relic_button_decorator(enabled: bool, name: &str) -> String {
+    let enabled_string = match enabled {
+        true => "[x]",
+        false => "[ ]"
+    };
+    format!("{} {}", enabled_string, name)
+}
+
 impl GuiHelper for TitleHelper {
     fn draw(&mut self, managers: &MemoryManagers, ui: &mut egui::Ui, _tab: &mut String) {
         ui.label(format!(
@@ -26,5 +34,13 @@ impl GuiHelper for TitleHelper {
             "Load Save Done: {:?}",
             managers.title_sequence_manager.data.load_save_done
         ));
+
+        ui.separator();
+
+        ui.label(format!("Relics (Total: {})", managers.title_sequence_manager.data.relic_buttons.count));
+        for relic in managers.title_sequence_manager.data.relic_buttons.buttons.iter() {
+            ui.label(relic_button_decorator(relic.enabled, &relic.name));
+        }
+
     }
 }

--- a/src/gui/helpers/title_helper.rs
+++ b/src/gui/helpers/title_helper.rs
@@ -12,14 +12,6 @@ impl TitleHelper {
     }
 }
 
-fn relic_button_decorator(enabled: bool, name: &str) -> String {
-    let enabled_string = match enabled {
-        true => "[x]",
-        false => "[  ]",
-    };
-    format!("{} {}", enabled_string, name)
-}
-
 impl GuiHelper for TitleHelper {
     fn draw(&mut self, managers: &MemoryManagers, ui: &mut egui::Ui, _tab: &mut String) {
         ui.label(format!(
@@ -91,7 +83,7 @@ impl GuiHelper for TitleHelper {
             .items
             .iter()
         {
-            ui.label(relic_button_decorator(relic.enabled, &relic.name));
+            ui.checkbox(&mut relic.enabled.clone(), &relic.name);
         }
     }
 }

--- a/src/gui/helpers/title_helper.rs
+++ b/src/gui/helpers/title_helper.rs
@@ -15,7 +15,7 @@ impl TitleHelper {
 fn relic_button_decorator(enabled: bool, name: &str) -> String {
     let enabled_string = match enabled {
         true => "[x]",
-        false => "[  ]"
+        false => "[  ]",
     };
     format!("{} {}", enabled_string, name)
 }
@@ -37,10 +37,18 @@ impl GuiHelper for TitleHelper {
 
         ui.separator();
 
-        ui.label(format!("Relics (Total: {})", managers.title_sequence_manager.data.relic_buttons.count));
-        for relic in managers.title_sequence_manager.data.relic_buttons.buttons.iter() {
+        ui.label(format!(
+            "Relics (Total: {})",
+            managers.title_sequence_manager.data.relic_buttons.count
+        ));
+        for relic in managers
+            .title_sequence_manager
+            .data
+            .relic_buttons
+            .items
+            .iter()
+        {
             ui.label(relic_button_decorator(relic.enabled, &relic.name));
         }
-
     }
 }

--- a/src/gui/helpers/title_helper.rs
+++ b/src/gui/helpers/title_helper.rs
@@ -40,6 +40,13 @@ impl GuiHelper for TitleHelper {
 
         ui.separator();
 
+        ui.label(format!(
+            "Current Screen Name: {:?}",
+            managers.title_sequence_manager.data.current_screen_name
+        ));
+
+        ui.separator();
+
         ui.label("New Game Character Select");
 
         ui.label(format!(

--- a/src/gui/helpers/title_helper.rs
+++ b/src/gui/helpers/title_helper.rs
@@ -15,7 +15,7 @@ impl TitleHelper {
 fn relic_button_decorator(enabled: bool, name: &str) -> String {
     let enabled_string = match enabled {
         true => "[x]",
-        false => "[ ]"
+        false => "[  ]"
     };
     format!("{} {}", enabled_string, name)
 }

--- a/src/gui/helpers/title_helper.rs
+++ b/src/gui/helpers/title_helper.rs
@@ -24,7 +24,10 @@ impl GuiHelper for TitleHelper {
     fn draw(&mut self, managers: &MemoryManagers, ui: &mut egui::Ui, _tab: &mut String) {
         ui.label(format!(
             "Menu Item Selected: {:?}",
-            managers.title_sequence_manager.data.title_menu.selected
+            managers
+                .title_sequence_manager
+                .data
+                .title_menu_option_selected
         ));
         ui.label(format!(
             "Pressed Start: {:?}",
@@ -33,6 +36,39 @@ impl GuiHelper for TitleHelper {
         ui.label(format!(
             "Load Save Done: {:?}",
             managers.title_sequence_manager.data.load_save_done
+        ));
+
+        ui.separator();
+
+        ui.label("New Game Character Select");
+
+        ui.label(format!(
+            "Left Character: {:?}",
+            managers
+                .title_sequence_manager
+                .data
+                .new_game_characters
+                .left
+                .character
+        ));
+
+        ui.label(format!(
+            "Right Character: {:?}",
+            managers
+                .title_sequence_manager
+                .data
+                .new_game_characters
+                .right
+                .character
+        ));
+
+        ui.label(format!(
+            "Selected Character: {:?}",
+            managers
+                .title_sequence_manager
+                .data
+                .new_game_characters
+                .selected
         ));
 
         ui.separator();

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -3,7 +3,6 @@ pub mod title_sequence_manager;
 
 use crate::state::StateContext;
 
-use log::error;
 use memory::memory_manager::unity::{UnityMemoryManagement, UnityMemoryManager};
 use memory::process::Error;
 use player_party_manager::PlayerPartyManagerData;

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -64,7 +64,6 @@ impl<T: MemoryManagerUpdate> MemoryManager<T> {
         match self.data.update(ctx, &mut self.manager) {
             Ok(_) => (),
             Err(_error) => {
-                error!("RESETTING");
                 self.manager.reset()
             }
         }

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -45,7 +45,7 @@ impl<T: MemoryManagerUpdate> MemoryManager<T> {
             }
 
             return true;
-        }
+        } 
         false
     }
 

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -2,6 +2,8 @@ pub mod objects;
 pub mod player_party_manager;
 pub mod title_sequence_manager;
 
+use log::error;
+
 use crate::state::StateContext;
 
 use memory::memory_manager::unity::{UnityMemoryManagement, UnityMemoryManager};
@@ -63,7 +65,10 @@ impl<T: MemoryManagerUpdate> MemoryManager<T> {
     fn update_memory(&mut self, ctx: &StateContext) {
         match self.data.update(ctx, &mut self.manager) {
             Ok(_) => (),
-            Err(_error) => self.manager.reset(),
+            Err(_error) => {
+                error!("Memory Update Error: Find the offending memory address and return a safe result.");
+                self.manager.reset()
+            },
         }
     }
 

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,3 +1,4 @@
+pub mod objects;
 pub mod player_party_manager;
 pub mod title_sequence_manager;
 
@@ -45,7 +46,7 @@ impl<T: MemoryManagerUpdate> MemoryManager<T> {
             }
 
             return true;
-        } 
+        }
         false
     }
 
@@ -62,9 +63,7 @@ impl<T: MemoryManagerUpdate> MemoryManager<T> {
     fn update_memory(&mut self, ctx: &StateContext) {
         match self.data.update(ctx, &mut self.manager) {
             Ok(_) => (),
-            Err(_error) => {
-                self.manager.reset()
-            }
+            Err(_error) => self.manager.reset(),
         }
     }
 

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -66,9 +66,9 @@ impl<T: MemoryManagerUpdate> MemoryManager<T> {
         match self.data.update(ctx, &mut self.manager) {
             Ok(_) => (),
             Err(_error) => {
-                error!("Memory Update Error: Find the offending memory address and return a safe result.");
+                error!("Memory Update Error in {}", self.name);
                 self.manager.reset()
-            },
+            }
         }
     }
 

--- a/src/memory/objects/character.rs
+++ b/src/memory/objects/character.rs
@@ -1,0 +1,43 @@
+#[derive(Debug, Default, Clone)]
+pub enum PlayerPartyCharacter {
+    #[default]
+    None,
+    Zale,
+    Valere,
+    Garl,
+    Serai,
+    Reshan,
+    Bst,
+    Moraine,
+    Unknown,
+}
+
+impl PlayerPartyCharacter {
+    // pub fn as_str(&self) -> &'static str {
+    //     match self {
+    //         Self::None => "None",
+    //         Self::Zale => "Zale",
+    //         Self::Valere => "Valere",
+    //         Self::Garl => "Garl",
+    //         Self::Serai => "Seraï",
+    //         Self::Reshan => "Resh'an",
+    //         Self::Bst => "B'st",
+    //         Self::Moraine => "Moraine",
+    //         Self::Unknown => "Unknown",
+    //     }
+    // }
+
+    pub fn parse(value: &str) -> Self {
+        match value.to_lowercase().as_ref() {
+            "none" => Self::None,
+            "zale" => Self::Zale,
+            "valere" => Self::Valere,
+            "garl" => Self::Garl,
+            "seraï" => Self::Serai,
+            "resh'an" => Self::Reshan,
+            "b'st" => Self::Bst,
+            "moraine" => Self::Moraine,
+            _ => Self::Unknown,
+        }
+    }
+}

--- a/src/memory/objects/character.rs
+++ b/src/memory/objects/character.rs
@@ -27,6 +27,14 @@ impl PlayerPartyCharacter {
     //     }
     // }
 
+    /// Parses the name provided to the enum
+    ///
+    /// In game code this can be:
+    /// - normally cased with special characters
+    /// - normally cased without special characters
+    /// - capitalized with no special characters
+    ///
+    /// This handles all cases gracefully.
     pub fn parse(value: &str) -> Self {
         match value.to_lowercase().as_ref() {
             "none" => Self::None,
@@ -34,8 +42,11 @@ impl PlayerPartyCharacter {
             "valere" => Self::Valere,
             "garl" => Self::Garl,
             "seraï" => Self::Serai,
+            "serai" => Self::Serai,
             "resh'an" => Self::Reshan,
+            "reshan" => Self::Reshan,
             "b'st" => Self::Bst,
+            "bst" => Self::Bst,
             "moraine" => Self::Moraine,
             _ => Self::Unknown,
         }

--- a/src/memory/objects/mod.rs
+++ b/src/memory/objects/mod.rs
@@ -1,0 +1,1 @@
+pub mod character;

--- a/src/memory/title_sequence_manager.rs
+++ b/src/memory/title_sequence_manager.rs
@@ -229,6 +229,8 @@ impl TitleSequenceManagerData {
 
                 let enabled = !matches!(enabled_str.trim(), "relic-switch-off");
 
+                // TODO(eein): perf - is it wise to allocate specifically sized array here on
+                // earlier in creation? maybe this can be added to the UnityItems implementation
                 buttons.push(RelicButton {
                     name: name.to_string(),
                     enabled

--- a/src/memory/title_sequence_manager.rs
+++ b/src/memory/title_sequence_manager.rs
@@ -3,8 +3,8 @@ use crate::state::StateContext;
 
 use log::info;
 
-use memory::game_engine::il2cpp::{Class, Module};
 use memory::game_engine::il2cpp::unity_items::{UnityItem, UnityItems};
+use memory::game_engine::il2cpp::{Class, Module};
 use memory::memory_manager::unity::UnityMemoryManager;
 use memory::process::Error;
 use memory::process::Process;
@@ -234,12 +234,7 @@ pub struct RelicButton {
 }
 
 impl UnityItem for RelicButton {
-    fn read(process: &Process, fields_base: u64, items_ptr: u64) -> Result<Self, Error> {
-        let item_ptr = process.read_pointer::<u64>(items_ptr + fields_base)?;
-        if item_ptr == 0 {
-            return Err(Error);
-        }
-
+    fn read(process: &Process, item_ptr: u64) -> Result<Self, Error> {
         let name_str =
             process.read_pointer_path::<ArrayWString<128>>(item_ptr, &[0x188, 0xD8, 0x14])?;
         let name = match String::from_utf16(name_str.as_slice()) {

--- a/src/memory/title_sequence_manager.rs
+++ b/src/memory/title_sequence_manager.rs
@@ -372,19 +372,24 @@ impl TitleSequenceManagerData {
             selected: right_selected,
         };
 
-        if !character_selected && (right.selected && !left.selected)
-            || (!right.selected && left.selected)
-        {
+        // character_selected means a character has been selected on the character
+        // select screen and is looking at relics, in this case None
+        //
+        // if character_selected is true in any case, it should be None
+        //
+        // check if left is 1 and right is 0: return left
+        // check if left is 0 and right is 1: return right
+        if character_selected {
+            selected = PlayerPartyCharacter::None;
+        } else {
+            // left selected but not right
             if left.selected && !right.selected {
                 selected = left.character.clone()
             }
+            // right selected but not left
             if right.selected && !left.selected {
                 selected = right.character.clone()
             }
-        }
-
-        if character_selected {
-            selected = PlayerPartyCharacter::None;
         }
 
         self.new_game_characters = NewGameCharacters {

--- a/src/memory/title_sequence_manager.rs
+++ b/src/memory/title_sequence_manager.rs
@@ -4,7 +4,7 @@ use crate::state::StateContext;
 
 use log::info;
 
-use memory::game_engine::il2cpp::unity_items::{UnityItem, UnityItems};
+use memory::game_engine::il2cpp::unity_list::{UnityList, UnityListItem};
 use memory::game_engine::il2cpp::{Class, Module};
 use memory::memory_manager::unity::UnityMemoryManager;
 use memory::process::Error;
@@ -34,7 +34,7 @@ pub struct TitleSequenceManagerData {
     /// Information on new game character selection
     pub new_game_characters: NewGameCharacters,
     // relicSelectionScreen -> relicButtons
-    pub relic_buttons: UnityItems<RelicButton>,
+    pub relic_buttons: UnityList<RelicButton>,
     /// If saves are loaded and continue shows up on the title screen.
     pub load_save_done: bool,
     /// If the player has pressed start on the intro screen.
@@ -206,7 +206,7 @@ impl TitleSequenceManagerData {
             module,
             &["relicSelectionScreen", "relicButtons"],
         ) {
-            let buttons = UnityItems::<RelicButton>::read(process, relic_buttons)?;
+            let buttons = UnityList::<RelicButton>::read(process, relic_buttons)?;
             self.relic_buttons = buttons;
         }
 
@@ -440,7 +440,7 @@ pub struct RelicButton {
     pub enabled: bool,
 }
 
-impl UnityItem for RelicButton {
+impl UnityListItem for RelicButton {
     fn read(process: &Process, item_ptr: u64) -> Result<Self, Error> {
         let name_str =
             process.read_pointer_path::<ArrayWString<128>>(item_ptr, &[0x188, 0xD8, 0x14])?;

--- a/src/memory/title_sequence_manager.rs
+++ b/src/memory/title_sequence_manager.rs
@@ -4,7 +4,7 @@ use crate::state::StateContext;
 
 use log::info;
 
-use memory::game_engine::il2cpp::unity_list::{UnityList, UnityListItem};
+use memory::game_engine::il2cpp::unity_list::{UnityItem, UnityList};
 use memory::game_engine::il2cpp::{Class, Module};
 use memory::memory_manager::unity::UnityMemoryManager;
 use memory::process::Error;
@@ -440,7 +440,7 @@ pub struct RelicButton {
     pub enabled: bool,
 }
 
-impl UnityListItem for RelicButton {
+impl UnityItem for RelicButton {
     fn read(process: &Process, item_ptr: u64) -> Result<Self, Error> {
         let name_str =
             process.read_pointer_path::<ArrayWString<128>>(item_ptr, &[0x188, 0xD8, 0x14])?;

--- a/src/memory/title_sequence_manager.rs
+++ b/src/memory/title_sequence_manager.rs
@@ -24,7 +24,11 @@ impl Default for MemoryManager<TitleSequenceManagerData> {
 
 #[derive(Default, Debug)]
 pub struct TitleSequenceManagerData {
+    /// Title Menu Object Data.
     pub title_menu: TitleMenu,
+    /// If saves are loaded and continue shows up on the title screen.
+    pub load_save_done: bool,
+    /// If the player has pressed start on the intro screen.
     pub pressed_start: bool,
 }
 
@@ -40,6 +44,7 @@ impl MemoryManagerUpdate for TitleSequenceManagerData {
                     if let Some(singleton) = manager.singleton {
                         self.update_title_menu(class, process, module, singleton)?;
                         self.update_pressed_start(class, process, module, singleton)?;
+                        self.update_load_save_done(class, process, module, singleton)?;
                     }
                 }
             }
@@ -49,6 +54,26 @@ impl MemoryManagerUpdate for TitleSequenceManagerData {
 }
 
 impl TitleSequenceManagerData {
+    pub fn update_load_save_done(
+        &mut self,
+        class: Class,
+        process: &Process,
+        module: &Module,
+        singleton: Class,
+    ) -> Result<(), Error> {
+        if let Ok(load_save_done) =
+            class.follow_fields::<u8>(singleton, process, module, &["loadSaveDone"])
+        {
+            self.load_save_done = match load_save_done {
+                1 => true,
+                0 => false,
+                _ => false,
+            };
+        }
+
+        Ok(())
+    }
+    
     pub fn update_pressed_start(
         &mut self,
         class: Class,

--- a/src/memory/title_sequence_manager.rs
+++ b/src/memory/title_sequence_manager.rs
@@ -26,6 +26,8 @@ impl Default for MemoryManager<TitleSequenceManagerData> {
 pub struct TitleSequenceManagerData {
     /// Title Menu Object Data.
     pub title_menu: TitleMenu,
+    // relicSelectionScreen -> relicButtons
+    pub relic_buttons: RelicButtons,
     /// If saves are loaded and continue shows up on the title screen.
     pub load_save_done: bool,
     /// If the player has pressed start on the intro screen.
@@ -45,6 +47,7 @@ impl MemoryManagerUpdate for TitleSequenceManagerData {
                         self.update_title_menu(class, process, module, singleton)?;
                         self.update_pressed_start(class, process, module, singleton)?;
                         self.update_load_save_done(class, process, module, singleton)?;
+                        self.update_relics(class, process, module, singleton)?;
                     }
                 }
             }
@@ -180,6 +183,67 @@ impl TitleSequenceManagerData {
         }
         Ok(())
     }
+    pub fn update_relics(
+        &mut self,
+        class: Class,
+        process: &Process,
+        module: &Module,
+        singleton: Class,
+    ) -> Result<(), Error> {
+        let mut buttons = vec![];
+
+        if let Ok(relic_buttons) = class.follow_fields::<u64>(singleton, process, module, &["relicSelectionScreen", "relicButtons"]) {
+            let mut fields_base = 0x20;
+            let offset = 0x8;
+
+            let items_ptr = process.read_pointer::<u64>(relic_buttons + 0x10)?;
+            let count = process.read_pointer::<u32>(items_ptr + 0x18)?;
+
+            if count == 0 { return Ok(()) }
+            
+            // TODO(eein): try to convert this items reader to be generic somehow
+            // maybe something like UnityItems<RelicButton> and have Relic Button implement how it
+            // gets and stores its own data with a UnityItem trait
+            for _index in 0..count {
+                let item_ptr = process.read_pointer::<u64>(items_ptr + fields_base)?;
+                if item_ptr == 0 { break; }
+
+                // NAME
+                let len = process.read_pointer_path::<u8>(item_ptr, &[0x188, 0xD8, 0x10])?;
+                let addr = process.read_pointer_path_without_read(item_ptr, &[0x188, 0xD8, 0x14])?;
+                
+                // Get the buffer for the name and store it
+                // TODO(eein): convert this utf8 string reader to a helper function
+                let mut buf = vec![0; (len * 2) as usize];
+                let current_read_buf = &mut buf[..(len * 2) as usize];
+                let current_read_buf = process.read_into_uninit_buf(addr, current_read_buf)?;
+                let name = std::str::from_utf8(current_read_buf).ok().unwrap();
+
+                // ENABLED 
+                // TODO(eein): rewrite this to a CSTR lookup looking for null terminator
+                let addr = process.read_pointer_path_without_read(item_ptr, &[0x1B0, 0xD8, 0x10, 0x30, 0x0])?;
+                let mut buf = [0; 16];
+                let current_read_buf = &mut buf[..16];
+                let current_read_buf = process.read_into_uninit_buf(addr, current_read_buf)?;
+                let enabled_str = std::str::from_utf8(current_read_buf).ok().unwrap();
+
+                let enabled = !matches!(enabled_str.trim(), "relic-switch-off");
+
+                buttons.push(RelicButton {
+                    name: name.to_string(),
+                    enabled
+                });
+
+                fields_base += offset;
+            }
+            self.relic_buttons = RelicButtons {
+                count,
+                buttons,
+            };
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Default, Debug)]
@@ -197,4 +261,20 @@ pub enum TitleMenuOption {
 #[derive(Default, Debug)]
 pub struct TitleMenu {
     pub selected: TitleMenuOption,
+}
+
+#[derive(Default, Debug)]
+pub struct RelicButtons {
+    pub count: u32, // 0x18
+    pub buttons: Vec<RelicButton>, // start at 0x20
+}
+
+#[derive(Default, Debug)]
+pub struct RelicButton {
+    // textfield -> m_Text -> Value
+    pub name: String,
+    // We check the on off switch state to determine if it is enabled or not.
+    // onOffSwitchImage -> m_Sprite -> m_CachedPtr -> ptr to base -> 0x0 = string
+    pub enabled: bool,
+
 }


### PR DESCRIPTION
This PR adds a few things
- Implementation of TitleSequenceManager fields (a new one over the old tas)
- A generic  way of accessing Unity vectors
- Some safety cleanup
- An ugly but much better working New Game Character Select helper (in comparison to old tas)
- Let the memory error message give context on whats crashing. No more try/except in this tas: handle everything.

Theres a few ugly checks for dangling pointers in this PR that will have to wait for memory propogation.

I want to put the errors in the actual memory modules, for example:
- `MemoryError::DanglingPointer`
- `MemoryError::NullAddress` (0x0)