### PR TITLE
fix: make fps meter less wild

### DIFF
--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -4,7 +4,7 @@ use super::gui::helpers::GuiHelpers;
 use super::memory::MemoryManagers;
 use super::state::State;
 use egui_dock::{DockArea, Style};
-use std::time::Instant;
+use std::time::{Duration, Instant};
 
 pub struct TabViewer<'a> {
     helpers: &'a mut GuiHelpers,
@@ -63,12 +63,19 @@ impl Gui {
 
                 // FPS Counter
                 let tnow = Instant::now();
-
                 let tprev = state.debug.last_update;
+                let tlastpinned = state.debug.last_pinned_update;
+
                 let fps_string = {
                     let dt = (tnow - tprev).as_secs_f64();
                     let fps = 1.0 / dt;
-                    format!("FPS: {}", fps.round())
+                    let out = fps.round();
+                    let since = tnow.duration_since(tlastpinned);
+                    if since > Duration::from_millis(100) {
+                        state.debug.last_pinned_update = tnow;
+                        state.debug.pinned_fps = out;
+                    }
+                    format!("FPS: {: >3}", state.debug.pinned_fps)
                 };
 
                 state.debug.last_update = tnow;

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -67,11 +67,11 @@ impl Gui {
                 let tlastpinned = state.debug.last_pinned_update;
 
                 let fps_string = {
-                    let dt = (tnow - tprev).as_secs_f64();
-                    let fps = 1.0 / dt;
-                    let out = fps.round();
                     let since = tnow.duration_since(tlastpinned);
-                    if since > Duration::from_millis(100) {
+                    if since >= Duration::from_millis(100) {
+                        let dt = (tnow - tprev).as_secs_f64();
+                        let fps = 1.0 / dt;
+                        let out = fps.round();
                         state.debug.last_pinned_update = tnow;
                         state.debug.pinned_fps = out;
                     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -12,6 +12,8 @@ use log::info;
 use std::time::Instant;
 
 pub struct StateDebug {
+    pub pinned_fps: f64,
+    pub last_pinned_update: Instant,
     pub last_update: Instant,
     pub last_memory_update: Instant,
 }
@@ -55,6 +57,8 @@ impl State {
                 dock_state: DockState::new(tree_names),
             },
             debug: StateDebug {
+                pinned_fps: 0.0,
+                last_pinned_update: Instant::now(),
                 last_update: Instant::now(),
                 last_memory_update: Instant::now(),
             },


### PR DESCRIPTION
This PR slows down the fps meter updates.

It still does the full timestep calculation (this can probably be improved later), but only takes a sample every 100ms.
It also left-pads so the number doesn't jump around.