### PR TITLE
feat/memory-errors-and-memory-context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /target
 /crates/**/target
+
+flamegraph.svg
+perf.data*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2489,6 +2489,7 @@ dependencies = [
 name = "sea-of-stars-tas"
 version = "0.1.0"
 dependencies = [
+ "bytemuck",
  "colog",
  "eframe",
  "egui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71b1793ee61086797f5c80b6efa2b8ffa6d5dd703f118545808a7f2e27f7046"
 
 [[package]]
+name = "accesskit"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74a4b14f3d99c1255dcba8f45621ab1a2e7540a0009652d33989005a4d0bfc6b"
+dependencies = [
+ "enumn",
+ "serde",
+]
+
+[[package]]
 name = "addr2line"
 version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -48,6 +58,7 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
+ "serde",
  "version_check",
  "zerocopy",
 ]
@@ -237,6 +248,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bindgen"
 version = "0.68.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -268,7 +288,7 @@ dependencies = [
  "bitflags 2.6.0",
  "cexpr",
  "clang-sys",
- "itertools",
+ "itertools 0.12.1",
  "lazy_static",
  "lazycell",
  "proc-macro2",
@@ -706,6 +726,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "dispatch"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -753,6 +782,7 @@ checksum = "2e6b451ff1143f6de0f33fc7f1b68fecfd2c7de06e104de96c4514de3f5396f8"
 dependencies = [
  "bytemuck",
  "emath",
+ "serde",
 ]
 
 [[package]]
@@ -795,11 +825,13 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20c97e70a2768de630f161bb5392cbd3874fcf72868f14df0e002e82e06cb798"
 dependencies = [
+ "accesskit",
  "ahash",
  "emath",
  "epaint",
  "log",
  "nohash-hasher",
+ "serde",
 ]
 
 [[package]]
@@ -831,6 +863,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "egui_extras"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bb783d9fa348f69ed5c340aa25af78b5472043090e8b809040e30960cc2a746"
+dependencies = [
+ "ahash",
+ "egui",
+ "enum-map",
+ "log",
+ "serde",
+]
+
+[[package]]
 name = "egui_glow"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -859,6 +904,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a6a21708405ea88f63d8309650b4d77431f4bc28fb9d8e6f77d3963b51249e6"
 dependencies = [
  "bytemuck",
+ "serde",
+]
+
+[[package]]
+name = "enum-map"
+version = "2.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6866f3bfdf8207509a033af1a75a7b08abda06bbaaeae6669323fd5a097df2e9"
+dependencies = [
+ "enum-map-derive",
+ "serde",
+]
+
+[[package]]
+name = "enum-map-derive"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
+]
+
+[[package]]
+name = "enumn"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -898,6 +976,7 @@ dependencies = [
  "log",
  "nohash-hasher",
  "parking_lot",
+ "serde",
 ]
 
 [[package]]
@@ -1235,6 +1314,7 @@ checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -1257,12 +1337,27 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
 dependencies = [
  "either",
 ]
+
+[[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
 
 [[package]]
 name = "jni"
@@ -1399,6 +1494,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
+name = "lz4_flex"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75761162ae2b0e580d7e7c390558127e5f01b4194debd6221fd8c207fc80e3f5"
+
+[[package]]
 name = "mach"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1527,6 +1628,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.52.0",
 ]
+
+[[package]]
+name = "natord"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "308d96db8debc727c3fd9744aac51751243420e46edf401010908da7f8d5e57c"
 
 [[package]]
 name = "ndk"
@@ -1677,6 +1784,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-integer"
@@ -2043,6 +2156,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
 name = "ppv-lite86"
 version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2116,6 +2235,41 @@ dependencies = [
  "libproc",
  "mach2",
  "winapi",
+]
+
+[[package]]
+name = "puffin"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa9dae7b05c02ec1a6bc9bcf20d8bc64a7dcbf57934107902a872014899b741f"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "byteorder",
+ "cfg-if",
+ "itertools 0.10.5",
+ "lz4_flex",
+ "once_cell",
+ "parking_lot",
+ "serde",
+]
+
+[[package]]
+name = "puffin_egui"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12b2260967a8707102a03276b30e6e4baaf6854ef6f316418683602ff6606716"
+dependencies = [
+ "egui",
+ "egui_extras",
+ "indexmap",
+ "natord",
+ "once_cell",
+ "parking_lot",
+ "puffin",
+ "time",
+ "vec1",
+ "web-time",
 ]
 
 [[package]]
@@ -2341,6 +2495,7 @@ dependencies = [
  "egui_dock",
  "log",
  "memory",
+ "puffin_egui",
  "seq",
  "sysinfo",
  "vec3-rs",
@@ -2585,6 +2740,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.3.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5dfd88e563464686c916c7e46e623e520ddc6d79fa6641390f2e3fa86e83e885"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
+
+[[package]]
+name = "time-macros"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f252a68540fde3a3877aeea552b832b40ab9a69e318efd078774a01ddee1ccf"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
 name = "tiny-skia"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2720,6 +2906,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "vec1"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eab68b56840f69efb0fefbe3ab6661499217ffdc58e2eef7c3f6f69835386322"
 
 [[package]]
 name = "vec2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 # joystick = { path = "crates/joystick", version = "0.1.0" }
 memory = { path = "crates/memory", version = "0.1.0" }
+bytemuck = { version = "1.18.0", features = ["min_const_generics"] }
 seq = { path = "crates/seq", version = "0.1.0" }
 sysinfo = { version = "0.31.2", default-features = false, features = ["system", "multithread"] }
 egui = "0.28"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ egui_dock = "0.13.0"
 vec3-rs = "0.1.6"
 colog = "1.3.0"
 log = "0.4.22"
+puffin_egui = "0.29.0"
 
 [dependencies.winit]
 # version = "*"

--- a/crates/memory/src/game_engine/il2cpp/mod.rs
+++ b/crates/memory/src/game_engine/il2cpp/mod.rs
@@ -286,7 +286,7 @@ impl Class {
         fields: &[&str],
     ) -> Result<T, MemoryError> {
         if fields.is_empty() {
-            return Err(MemoryError::Unset);
+            return Err(MemoryError::InvalidParameters);
         }
 
         if singleton.class == 0 {
@@ -324,7 +324,7 @@ impl Class {
         fields: &[&str],
     ) -> Result<u64, MemoryError> {
         if fields.is_empty() {
-            return Err(MemoryError::Unset);
+            return Err(MemoryError::InvalidParameters);
         }
 
         if singleton.class == 0 {

--- a/crates/memory/src/game_engine/il2cpp/mod.rs
+++ b/crates/memory/src/game_engine/il2cpp/mod.rs
@@ -2,7 +2,7 @@
 pub mod unity_list;
 
 use crate::pe;
-use crate::process::Error;
+use crate::process::MemoryError;
 use crate::process::Process;
 use crate::signature::Signature;
 use crate::string::ArrayCString;
@@ -129,7 +129,7 @@ impl Assembly {
         &self,
         process: &Process,
         module: &Module,
-    ) -> Result<ArrayCString<N>, Error> {
+    ) -> Result<ArrayCString<N>, MemoryError> {
         process.read(process.read_pointer(
             self.assembly
                 + module.offsets.monoassembly_aname as u64
@@ -166,7 +166,7 @@ impl Image {
         let metadata_ptr = match type_count {
             Ok(_) => process
                 .read_pointer::<u64>(self.image + module.offsets.monoimage_metadatahandle as u64),
-            _ => Err(Error {}),
+            _ => Err(MemoryError::ReadError {}),
         };
         let metadata_handle = match type_count {
             Ok(0) => None,
@@ -211,7 +211,7 @@ impl Class {
         &self,
         process: &Process,
         module: &Module,
-    ) -> Result<ArrayCString<N>, Error> {
+    ) -> Result<ArrayCString<N>, MemoryError> {
         process.read_pointer_path(self.class, &[module.offsets.monoclass_name.into(), 0x0])
     }
 
@@ -219,7 +219,7 @@ impl Class {
         &self,
         process: &Process,
         module: &Module,
-    ) -> Result<ArrayCString<N>, Error> {
+    ) -> Result<ArrayCString<N>, MemoryError> {
         process.read_pointer_path::<ArrayCString<N>>(
             self.class,
             &[module.offsets.monoclass_name_space.into(), 0x0],
@@ -284,13 +284,13 @@ impl Class {
         process: &Process,
         module: &Module,
         fields: &[&str],
-    ) -> Result<T, Error> {
+    ) -> Result<T, MemoryError> {
         if fields.is_empty() {
-            return Err(Error);
+            return Err(MemoryError::Unset);
         }
 
         if singleton.class == 0 {
-            return Err(Error);
+            return Err(MemoryError::NullPointer);
         }
 
         let last = fields.last().unwrap();
@@ -310,7 +310,7 @@ impl Class {
                         fields_base.class = process.read_pointer::<u64>(address.class)?;
                     }
                 }
-                None => return Err(Error),
+                None => return Err(MemoryError::ReadError),
             };
         }
         process.read_pointer::<T>(address.class)
@@ -322,13 +322,13 @@ impl Class {
         process: &Process,
         module: &Module,
         fields: &[&str],
-    ) -> Result<u64, Error> {
+    ) -> Result<u64, MemoryError> {
         if fields.is_empty() {
-            return Err(Error);
+            return Err(MemoryError::Unset);
         }
 
         if singleton.class == 0 {
-            return Err(Error);
+            return Err(MemoryError::NullPointer);
         }
 
         let last = fields.last().unwrap();
@@ -340,6 +340,9 @@ impl Class {
         for field in fields {
             match fields_base.get_field_offset(process, module, field) {
                 Some(offset) => {
+                    if address.class == 0 {
+                        return Err(MemoryError::NullPointer);
+                    }
                     if field == last {
                         address.class += offset as u64;
                     } else {
@@ -348,7 +351,7 @@ impl Class {
                         fields_base.class = process.read_pointer::<u64>(address.class)?;
                     }
                 }
-                None => return Err(Error),
+                None => return Err(MemoryError::ReadError),
             };
         }
         Ok(address.class)
@@ -428,7 +431,7 @@ impl Field {
         &self,
         process: &Process,
         module: &Module,
-    ) -> Result<ArrayCString<N>, Error> {
+    ) -> Result<ArrayCString<N>, MemoryError> {
         process.read_pointer_path::<ArrayCString<N>>(
             self.field,
             &[module.offsets.monoclassfield_name.into(), 0x0],

--- a/crates/memory/src/game_engine/il2cpp/unity_list.rs
+++ b/crates/memory/src/game_engine/il2cpp/unity_list.rs
@@ -1,4 +1,4 @@
-use crate::process::{Error, Process};
+use crate::process::{MemoryError, Process};
 
 #[derive(Default, Debug)]
 pub struct UnityList<T: UnityItem> {
@@ -22,7 +22,7 @@ const COUNT_OFFSET: u64 = 0x18;
 ///  ```
 
 impl<T: UnityItem> UnityList<T> {
-    pub fn read(process: &Process, addr: u64) -> Result<Self, Error> {
+    pub fn read(process: &Process, addr: u64) -> Result<Self, MemoryError> {
         let mut items = vec![];
         let mut fields_base = ITEMS_0_INDEX_BASE;
 
@@ -62,7 +62,7 @@ impl<T: UnityItem> UnityList<T> {
 
 /// Trait provided
 pub trait UnityItem {
-    fn read(process: &Process, item_ptr: u64) -> Result<Self, Error>
+    fn read(process: &Process, item_ptr: u64) -> Result<Self, MemoryError>
     where
         Self: Sized;
 }

--- a/crates/memory/src/pe.rs
+++ b/crates/memory/src/pe.rs
@@ -2,7 +2,7 @@
 
 use core::{fmt, mem};
 
-use crate::process::{Error, Process};
+use crate::process::{MemoryError, Process};
 use bytemuck::{Pod, Zeroable};
 
 use crate::string::ArrayCString;
@@ -285,7 +285,7 @@ impl Symbol {
     pub fn get_name<const CAP: usize>(
         &self,
         process: &Process,
-    ) -> Result<ArrayCString<CAP>, Error> {
+    ) -> Result<ArrayCString<CAP>, MemoryError> {
         process.read(self.name_addr)
     }
 }

--- a/crates/memory/src/process.rs
+++ b/crates/memory/src/process.rs
@@ -33,8 +33,6 @@ pub enum MemoryError {
     ReadError,         // when memory cant be read
 }
 
-pub struct Error;
-
 pub struct Process {
     pub handle: ProcessHandle,
     pub pid: Pid,

--- a/crates/memory/src/process.rs
+++ b/crates/memory/src/process.rs
@@ -28,9 +28,9 @@ pub enum ModuleError {
 #[derive(Debug)]
 pub enum MemoryError {
     InvalidParameters, // When some parameters are invalid
-    NullPointer, // When a ptr is 0
-    Unset,       // When a value is unset (ie None)
-    ReadError,   // when memory cant be read
+    NullPointer,       // When a ptr is 0
+    Unset,             // When a value is unset (ie None)
+    ReadError,         // when memory cant be read
 }
 
 pub struct Error;

--- a/crates/memory/src/process.rs
+++ b/crates/memory/src/process.rs
@@ -27,6 +27,7 @@ pub enum ModuleError {
 
 #[derive(Debug)]
 pub enum MemoryError {
+    InvalidParameters, // When some parameters are invalid
     NullPointer, // When a ptr is 0
     Unset,       // When a value is unset (ie None)
     ReadError,   // when memory cant be read
@@ -136,7 +137,7 @@ impl Process {
         mut address: u64,
         path: &[u64],
     ) -> Result<T, MemoryError> {
-        let (&last, path) = path.split_last().ok_or(MemoryError::Unset)?;
+        let (&last, path) = path.split_last().ok_or(MemoryError::InvalidParameters)?;
         for &offset in path {
             address = self.read_pointer::<u64>(address + offset)?;
         }
@@ -149,7 +150,7 @@ impl Process {
         mut address: u64,
         path: &[u64],
     ) -> Result<u64, MemoryError> {
-        let (&last, path) = path.split_last().ok_or(MemoryError::Unset)?;
+        let (&last, path) = path.split_last().ok_or(MemoryError::InvalidParameters)?;
         for &offset in path {
             address = self.read_pointer::<u64>(address + offset)?;
         }

--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,9 @@
             pkg-config
             openssl
             xorg.libxcb
+            linuxPackages_latest.perf
             # wasm-pack
+            cargo-flamegraph
             rust-analyzer
             rustfmt
             # wasm-bindgen-cli

--- a/src/memory/memory_context.rs
+++ b/src/memory/memory_context.rs
@@ -23,24 +23,18 @@ impl<'a> MemoryContext<'a> {
             if let Some(process) = &ctx.process {
                 if let Some(module) = &ctx.module {
                     if let Some(singleton) = &manager.singleton {
-                        Ok(Self {
+                        return Ok(Self {
                             class,
                             process,
                             module,
                             singleton,
-                        })
-                    } else {
-                        Err(MemoryError::Unset)
+                        });
                     }
-                } else {
-                    Err(MemoryError::Unset)
                 }
-            } else {
-                Err(MemoryError::Unset)
             }
-        } else {
-            Err(MemoryError::Unset)
         }
+
+        Err(MemoryError::Unset)
     }
 
     pub fn follow_fields<T: Pod>(&self, fields: &[&str]) -> Result<T, MemoryError> {

--- a/src/memory/memory_context.rs
+++ b/src/memory/memory_context.rs
@@ -1,0 +1,54 @@
+use bytemuck::Pod;
+use memory::game_engine::il2cpp::{Class, Module};
+use memory::memory_manager::unity::UnityMemoryManager;
+use memory::process::{MemoryError, Process};
+
+// TODO(eein): is it possible to make this more generic so it can be
+// moved into memory crate?
+use crate::state::StateContext;
+
+pub struct MemoryContext<'a> {
+    pub class: &'a Class,
+    pub process: &'a Process,
+    pub module: &'a Module,
+    pub singleton: &'a Class,
+}
+
+impl<'a> MemoryContext<'a> {
+    pub fn create(
+        ctx: &'a StateContext,
+        manager: &'a mut UnityMemoryManager,
+    ) -> Result<MemoryContext<'a>, MemoryError> {
+        if let Some(class) = &manager.class {
+            if let Some(process) = &ctx.process {
+                if let Some(module) = &ctx.module {
+                    if let Some(singleton) = &manager.singleton {
+                        Ok(Self {
+                            class,
+                            process,
+                            module,
+                            singleton,
+                        })
+                    } else {
+                        Err(MemoryError::Unset)
+                    }
+                } else {
+                    Err(MemoryError::Unset)
+                }
+            } else {
+                Err(MemoryError::Unset)
+            }
+        } else {
+            Err(MemoryError::Unset)
+        }
+    }
+
+    pub fn follow_fields<T: Pod>(&self, fields: &[&str]) -> Result<T, MemoryError> {
+        self.class
+            .follow_fields::<T>(*self.singleton, self.process, self.module, fields)
+    }
+
+    pub fn read_pointer<T: Pod>(&self, addr: u64) -> Result<T, MemoryError> {
+        self.process.read_pointer::<T>(addr)
+    }
+}

--- a/src/memory/memory_context.rs
+++ b/src/memory/memory_context.rs
@@ -48,7 +48,17 @@ impl<'a> MemoryContext<'a> {
             .follow_fields::<T>(*self.singleton, self.process, self.module, fields)
     }
 
+    pub fn read_pointer_path_without_read(&self, path: &[u64]) -> Result<u64, MemoryError> {
+        self.process
+            .read_pointer_path_without_read(self.singleton.class, path)
+    }
+
     pub fn read_pointer<T: Pod>(&self, addr: u64) -> Result<T, MemoryError> {
         self.process.read_pointer::<T>(addr)
+    }
+
+    pub fn get_field_offset(&self, field: &str) -> Option<u32> {
+        self.class
+            .get_field_offset(self.process, self.module, field)
     }
 }

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,3 +1,4 @@
+pub mod memory_context;
 pub mod objects;
 pub mod player_party_manager;
 pub mod title_sequence_manager;
@@ -68,7 +69,7 @@ impl<T: MemoryManagerUpdate> MemoryManager<T> {
                 );
                 match error {
                     MemoryError::ReadError => self.manager.reset(),
-                    MemoryError::NullPointer => {},
+                    MemoryError::NullPointer => {}
                     MemoryError::Unset => self.manager.reset(),
                     MemoryError::InvalidParameters => {}
                 }

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -45,14 +45,7 @@ impl MemoryManagers {
 
 impl<T: MemoryManagerUpdate> MemoryManager<T> {
     fn ready_for_updates(&mut self, _ctx: &StateContext) -> bool {
-        if let Some(class) = self.manager.singleton {
-            if class.class == 0 {
-                return false;
-            }
-
-            return true;
-        }
-        false
+        matches!(self.manager.singleton, Some(_val))
     }
 
     fn update_manager(&mut self, ctx: &StateContext) {
@@ -75,8 +68,9 @@ impl<T: MemoryManagerUpdate> MemoryManager<T> {
                 );
                 match error {
                     MemoryError::ReadError => self.manager.reset(),
-                    MemoryError::NullPointer => {}
-                    MemoryError::Unset => {}
+                    MemoryError::NullPointer => {},
+                    MemoryError::Unset => self.manager.reset(),
+                    MemoryError::InvalidParameters => {}
                 }
             }
         }

--- a/src/memory/player_party_manager.rs
+++ b/src/memory/player_party_manager.rs
@@ -2,7 +2,7 @@ use crate::memory::{MemoryManager, MemoryManagerUpdate};
 use crate::state::StateContext;
 use log::info;
 use memory::memory_manager::unity::UnityMemoryManager;
-use memory::process::Error;
+use memory::process::MemoryError;
 use vec3_rs::Vector3;
 
 impl Default for MemoryManager<PlayerPartyManagerData> {
@@ -29,7 +29,7 @@ impl MemoryManagerUpdate for PlayerPartyManagerData {
         &mut self,
         ctx: &StateContext,
         manager: &mut UnityMemoryManager,
-    ) -> Result<(), Error> {
+    ) -> Result<(), MemoryError> {
         match self.update_position(ctx, manager) {
             Ok(_) => Ok(()),
             Err(error) => Err(error),
@@ -46,7 +46,7 @@ impl PlayerPartyManagerData {
         &mut self,
         ctx: &StateContext,
         manager: &mut UnityMemoryManager,
-    ) -> Result<(), Error> {
+    ) -> Result<(), MemoryError> {
         if let Some(class) = manager.class {
             if let Some(process) = &ctx.process {
                 if let Some(module) = &ctx.module {

--- a/src/memory/player_party_manager.rs
+++ b/src/memory/player_party_manager.rs
@@ -1,3 +1,4 @@
+use crate::memory::memory_context::MemoryContext;
 use crate::memory::{MemoryManager, MemoryManagerUpdate};
 use crate::state::StateContext;
 use log::info;
@@ -30,10 +31,11 @@ impl MemoryManagerUpdate for PlayerPartyManagerData {
         ctx: &StateContext,
         manager: &mut UnityMemoryManager,
     ) -> Result<(), MemoryError> {
-        match self.update_position(ctx, manager) {
-            Ok(_) => Ok(()),
-            Err(error) => Err(error),
-        }
+        let memory_context = MemoryContext::create(ctx, manager)?;
+
+        self.update_position(&memory_context)?;
+
+        Ok(())
     }
 }
 
@@ -42,28 +44,14 @@ impl PlayerPartyManagerData {
     // Unfortunately because some classes here dont have true objects
     // this by using follow_fields since while we are going up the chain
     // we may be unable to query an object without a fields_base
-    pub fn update_position(
-        &mut self,
-        ctx: &StateContext,
-        manager: &mut UnityMemoryManager,
-    ) -> Result<(), MemoryError> {
-        if let Some(class) = manager.class {
-            if let Some(process) = &ctx.process {
-                if let Some(module) = &ctx.module {
-                    if let Some(singleton) = manager.singleton {
-                        if let Some(leader) = class.get_field_offset(process, module, "leader") {
-                            let current_position_ptr = process.read_pointer_path_without_read(
-                                singleton.class,
-                                &[leader.into(), 0x90, 0x84],
-                            )?;
-                            let x = process.read_pointer::<f32>(current_position_ptr)?;
-                            let y = process.read_pointer::<f32>(current_position_ptr + 0x4)?;
-                            let z = process.read_pointer::<f32>(current_position_ptr + 0x8)?;
-                            self.position = Vector3::new(x, y, z);
-                        }
-                    }
-                }
-            }
+    pub fn update_position(&mut self, memory_context: &MemoryContext) -> Result<(), MemoryError> {
+        if let Some(leader) = memory_context.get_field_offset("leader") {
+            let current_position_ptr =
+                memory_context.read_pointer_path_without_read(&[leader.into(), 0x90, 0x84])?;
+            let x = memory_context.read_pointer::<f32>(current_position_ptr)?;
+            let y = memory_context.read_pointer::<f32>(current_position_ptr + 0x4)?;
+            let z = memory_context.read_pointer::<f32>(current_position_ptr + 0x8)?;
+            self.position = Vector3::new(x, y, z);
         }
         Ok(())
     }

--- a/src/memory/title_sequence_manager.rs
+++ b/src/memory/title_sequence_manager.rs
@@ -57,7 +57,7 @@ impl MemoryManagerUpdate for TitleSequenceManagerData {
             self.update_title_menu(&memory_context)?;
         }
 
-        if self.current_screen_name == "UpdateRelics" {
+        if self.current_screen_name == "RelicSelection" {
             self.update_relics(&memory_context)?;
         }
 

--- a/src/memory/title_sequence_manager.rs
+++ b/src/memory/title_sequence_manager.rs
@@ -51,16 +51,27 @@ impl MemoryManagerUpdate for TitleSequenceManagerData {
             if let Some(process) = &ctx.process {
                 if let Some(module) = &ctx.module {
                     if let Some(singleton) = manager.singleton {
-                        self.update_current_screen_name(class, process, module, singleton)?;
-                        self.update_title_menu(class, process, module, singleton)?;
+                        // Only update title menu if pressed start
                         self.update_pressed_start(class, process, module, singleton)?;
-                        self.update_load_save_done(class, process, module, singleton)?;
-                        self.update_relics(class, process, module, singleton)?;
-                        self.update_new_game_characters(class, process, module, singleton)?;
-                    }
-                }
-            }
-        }
+                        self.update_current_screen_name(class, process, module, singleton)?;
+
+                        if self.pressed_start && self.current_screen_name == "TitleScreen" {
+                            self.update_load_save_done(class, process, module, singleton)?;
+                            self.update_title_menu(class, process, module, singleton)?;
+                        }
+
+                        if self.current_screen_name == "UpdateRelics" {
+                            self.update_relics(class, process, module, singleton)?;
+                        }
+
+                        if self.current_screen_name == "CharacterSelection" {
+                            self.update_new_game_characters(class, process, module, singleton)?;
+                        }
+
+                    } else { return Err(MemoryError::Unset) }
+                } else { return Err(MemoryError::Unset) }
+            } else { return Err(MemoryError::Unset) }
+        } else { return Err(MemoryError::Unset) }
         Ok(())
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -38,7 +38,7 @@ pub struct StateContext {
 }
 
 impl State {
-    pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
+    pub fn new(_cc: &eframe::CreationContext<'_>) -> Self {
         // Register any GUI helpers here
         let gui_helpers = GuiHelpers::default();
 
@@ -142,7 +142,7 @@ impl eframe::App for State {
         // use puffin_egui::puffin;
         // puffin::set_scopes_on(true);
         // puffin_egui::profiler_window(ctx);
-        // use 
+        // use
         // `puffin::profile_function!();
         // if you want to profile a function
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -38,7 +38,7 @@ pub struct StateContext {
 }
 
 impl State {
-    pub fn new(_cc: &eframe::CreationContext<'_>) -> Self {
+    pub fn new(cc: &eframe::CreationContext<'_>) -> Self {
         // Register any GUI helpers here
         let gui_helpers = GuiHelpers::default();
 
@@ -138,6 +138,14 @@ impl eframe::App for State {
 
     /// Called each time the UI needs repainting, which may be many times per second.
     fn update(&mut self, ctx: &egui::Context, frame: &mut eframe::Frame) {
+        // Uncomment for puffin profiler
+        // use puffin_egui::puffin;
+        // puffin::set_scopes_on(true);
+        // puffin_egui::profiler_window(ctx);
+        // use 
+        // `puffin::profile_function!();
+        // if you want to profile a function
+
         // Put your widgets into a `SidePanel`, `TopBottomPanel`, `CentralPanel`, `Window` or `Area`.
         // For inspiration and more examples, go to https://emilk.github.io/egui
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -143,7 +143,7 @@ impl eframe::App for State {
         // puffin::set_scopes_on(true);
         // puffin_egui::profiler_window(ctx);
         // use
-        // `puffin::profile_function!();
+        // puffin::profile_function!();
         // if you want to profile a function
 
         // Put your widgets into a `SidePanel`, `TopBottomPanel`, `CentralPanel`, `Window` or `Area`.


### PR DESCRIPTION
This PR adds/fixes:
- memory context
- intitial implementation of wrapped memory context functions
- propogates memory errors using new memory error types
- does some checks for title seq manager to make it a bit faster
- converts title seq manager and player party manager to memory context

dependencies:
- adds puffin egui and leaves commented note about how to use it. VERY USEFUL; basically runs a live flamegraph of profiled functions within an egui frame. We can probably integrate this into a debug tab down the road and leave the initialization so functions can be profiled quickly. ([will add a tracking PR](https://github.com/Eein/sea-of-stars-tas/issues/37))

closes #35
closes #9 