### PR TITLE
feat: adds gameobject position and movement state

### DIFF
--- a/src/gui/helpers/nav_helper.rs
+++ b/src/gui/helpers/nav_helper.rs
@@ -23,10 +23,13 @@ impl NavHelper {
 
 impl GuiHelper for NavHelper {
     fn draw(&mut self, managers: &MemoryManagers, ui: &mut egui::Ui, _tab: &mut String) {
-        ui.label(format!("Movement State: {}", "Not Implemented!"));
+        ui.label(format!(
+            "Movement State: {:?}",
+            managers.player_party_manager.data.movement_state
+        ));
         ui.separator();
 
-        egui::CollapsingHeader::new("Player Coordinates NOT IMPLEMENTED")
+        egui::CollapsingHeader::new("Player Coordinates")
             .default_open(true)
             .show(ui, |ui| {
                 let position = managers.player_party_manager.data.position;
@@ -41,14 +44,14 @@ impl GuiHelper for NavHelper {
                     self.target_coordinates =
                         Vector3::new(position.get_x(), position.get_y(), position.get_z())
                 };
-                if ui.button("Copy to clipboard").clicked() {
+                if ui.button("Copy to clipboard NOT IMPLEMENTED").clicked() {
                     let text = "YOU COPIED THIS TEXT FROM THE CLIPBOARD";
                     ui.output_mut(|o| o.copied_text = String::from(text));
                     // nothing yet
                 };
             });
 
-        egui::CollapsingHeader::new("Target Coordinates NOT IMPLEMENTED")
+        egui::CollapsingHeader::new("Target Coordinates")
             .default_open(true)
             .show(ui, |ui| {
                 let position = self.target_coordinates;
@@ -66,12 +69,13 @@ impl GuiHelper for NavHelper {
                     format!("Distance to target {:.3}", distance_to_target);
                 ui.label(distance_to_target_string);
 
-                if ui.button("Copy to clipboard").clicked() {
+                if ui.button("Copy to clipboard NOT IMPLEMENTED").clicked() {
                     let text = "YOU COPIED THIS TEXT FROM THE CLIPBOARD";
                     ui.output_mut(|o| o.copied_text = String::from(text));
                 };
             });
         ui.separator();
+        ui.label("NOT IMPLEMENTED");
         ui.add(egui::Slider::new(&mut self.precision, 0.0..=100.0).text("Precision"));
         if ui.button("Navigate to target").clicked() {
             // nothing yet
@@ -82,10 +86,10 @@ impl GuiHelper for NavHelper {
         };
         ui.separator();
 
-        egui::CollapsingHeader::new("Gameobject Coordinates NOT IMPLEMENTED")
+        egui::CollapsingHeader::new("Gameobject Coordinates")
             .default_open(true)
             .show(ui, |ui| {
-                let position = managers.player_party_manager.data.position;
+                let position = managers.player_party_manager.data.gameobject_position;
                 let pos_x = format!("{:.3}", position.get_x());
                 let pos_y = format!("{:.3}", position.get_y());
                 let pos_z = format!("{:.3}", position.get_z());
@@ -93,7 +97,9 @@ impl GuiHelper for NavHelper {
                 ui.label(format!("y: {}", pos_y));
                 ui.label(format!("z: {}", pos_z));
 
-                if ui.button("Copy to clipboard").clicked() {
+                if ui.button("Copy to clipboard NOT IMPLEMENTED").clicked() {
+                    let text = "YOU COPIED THIS TEXT FROM THE CLIPBOARD";
+                    ui.output_mut(|o| o.copied_text = String::from(text));
                     // nothing yet
                 };
             });
@@ -109,6 +115,8 @@ impl GuiHelper for NavHelper {
                 ui.label(format!("z: {}", pos_z));
 
                 if ui.button("Copy to clipboard").clicked() {
+                    let text = "YOU COPIED THIS TEXT FROM THE CLIPBOARD";
+                    ui.output_mut(|o| o.copied_text = String::from(text));
                     // nothing yet
                 };
                 ui.label(format!("Rot (yaw): {}", pos_z));

--- a/src/memory/memory_context.rs
+++ b/src/memory/memory_context.rs
@@ -1,4 +1,4 @@
-use bytemuck::Pod;
+use bytemuck::{CheckedBitPattern, Pod};
 use memory::game_engine::il2cpp::{Class, Module};
 use memory::memory_manager::unity::UnityMemoryManager;
 use memory::process::{MemoryError, Process};
@@ -45,6 +45,14 @@ impl<'a> MemoryContext<'a> {
     pub fn read_pointer_path_without_read(&self, path: &[u64]) -> Result<u64, MemoryError> {
         self.process
             .read_pointer_path_without_read(self.singleton.class, path)
+    }
+
+    pub fn read_pointer_path<T: CheckedBitPattern + Pod>(
+        &self,
+        path: &[u64],
+    ) -> Result<T, MemoryError> {
+        self.process
+            .read_pointer_path::<T>(self.singleton.class, path)
     }
 
     pub fn read_pointer<T: Pod>(&self, addr: u64) -> Result<T, MemoryError> {

--- a/src/memory/player_party_manager.rs
+++ b/src/memory/player_party_manager.rs
@@ -23,6 +23,9 @@ impl Default for MemoryManager<PlayerPartyManagerData> {
 #[derive(Default, Debug)]
 pub struct PlayerPartyManagerData {
     pub position: Vector3<f32>,
+    pub gameobject_position: Vector3<f32>,
+    pub leader_offset: Option<u32>,
+    pub movement_state: PlayerMovementState,
 }
 
 impl MemoryManagerUpdate for PlayerPartyManagerData {
@@ -33,26 +36,101 @@ impl MemoryManagerUpdate for PlayerPartyManagerData {
     ) -> Result<(), MemoryError> {
         let memory_context = MemoryContext::create(ctx, manager)?;
 
-        self.update_position(&memory_context)?;
+        self.update_leader_offset(&memory_context)?;
+
+        if self.leader_offset.is_some() {
+            self.update_position(&memory_context)?;
+            self.update_gameobject_position(&memory_context)?;
+            self.update_movement_state(&memory_context)?;
+        }
 
         Ok(())
     }
 }
 
 impl PlayerPartyManagerData {
-    // This function updates the users position for nav helper
-    // Unfortunately because some classes here dont have true objects
-    // this by using follow_fields since while we are going up the chain
-    // we may be unable to query an object without a fields_base
-    pub fn update_position(&mut self, memory_context: &MemoryContext) -> Result<(), MemoryError> {
-        if let Some(leader) = memory_context.get_field_offset("leader") {
-            let current_position_ptr =
-                memory_context.read_pointer_path_without_read(&[leader.into(), 0x90, 0x84])?;
-            let x = memory_context.read_pointer::<f32>(current_position_ptr)?;
-            let y = memory_context.read_pointer::<f32>(current_position_ptr + 0x4)?;
-            let z = memory_context.read_pointer::<f32>(current_position_ptr + 0x8)?;
-            self.position = Vector3::new(x, y, z);
-        }
+    // Updates the dangling `leader` offset for the controller
+    // TODO(eein): is this actually true? It might have been one off issue.
+    // This value does not have a true field name so can't be queried with
+    // follow fields.
+    //
+    // NOTE(eein): I believe the internal memory function captures any
+    // errors but thats also not clear. Maybe make it a little more aggressive
+    // and error
+    pub fn update_leader_offset(
+        &mut self,
+        memory_context: &MemoryContext,
+    ) -> Result<(), MemoryError> {
+        self.leader_offset = memory_context.get_field_offset("leader");
         Ok(())
     }
+
+    pub fn update_position(&mut self, memory_context: &MemoryContext) -> Result<(), MemoryError> {
+        let leader_offset = self.leader_offset.unwrap();
+
+        let current_position_ptr =
+            memory_context.read_pointer_path_without_read(&[leader_offset.into(), 0x90, 0x84])?;
+
+        let x = memory_context.read_pointer::<f32>(current_position_ptr)?;
+        let y = memory_context.read_pointer::<f32>(current_position_ptr + 0x4)?;
+        let z = memory_context.read_pointer::<f32>(current_position_ptr + 0x8)?;
+
+        self.position = Vector3::new(x, y, z);
+
+        Ok(())
+    }
+
+    pub fn update_gameobject_position(
+        &mut self,
+        memory_context: &MemoryContext,
+    ) -> Result<(), MemoryError> {
+        let leader_offset = self.leader_offset.unwrap();
+
+        let gameobject_ptr = memory_context.read_pointer_path_without_read(&[
+            leader_offset.into(),
+            0x30,
+            0x48,
+            0x1C,
+        ])?;
+
+        let x = memory_context.read_pointer::<f32>(gameobject_ptr)?;
+        let y = memory_context.read_pointer::<f32>(gameobject_ptr + 0x4)?;
+        let z = memory_context.read_pointer::<f32>(gameobject_ptr + 0x8)?;
+
+        self.gameobject_position = Vector3::new(x, y, z);
+
+        Ok(())
+    }
+
+    pub fn update_movement_state(
+        &mut self,
+        memory_context: &MemoryContext,
+    ) -> Result<(), MemoryError> {
+        let leader_offset = self.leader_offset.unwrap();
+
+        if let Ok(movement_state) =
+            memory_context.read_pointer_path::<u8>(&[leader_offset.into(), 0x88, 0x50, 0x8C])
+        {
+            self.movement_state = match movement_state {
+                0 => PlayerMovementState::None,
+                1 => PlayerMovementState::Running,
+                2 => PlayerMovementState::Walking,
+                3 => PlayerMovementState::Idle,
+                _ => PlayerMovementState::None,
+            }
+        };
+
+        Ok(())
+    }
+}
+
+// PlayerDefaultState.EState
+// #
+#[derive(Default, Debug)]
+pub enum PlayerMovementState {
+    #[default]
+    None = 0,
+    Running = 1,
+    Walking = 2,
+    Idle = 3,
 }


### PR DESCRIPTION
On hold for #9 

Change base before merge.

This PR adds:
- saves leader offset for reuse (perf/sanity)
- gameobject position
- movement state
- updates the nav helper a bit

This is all I'll do for the moment on this until the other methods are needed.