### PR TITLE
feat: adds encounter active + combat controller mvp

### DIFF
--- a/src/gui/helpers/debug_helper.rs
+++ b/src/gui/helpers/debug_helper.rs
@@ -25,6 +25,12 @@ impl GuiHelper for DebugHelper {
         let level_manager = &game_state.memory_managers.level_manager.data;
         let new_dialog_manager = &game_state.memory_managers.new_dialog_manager.data;
         let cutscene_manager = &game_state.memory_managers.cutscene_manager.data;
+        let combat_manager = &game_state.memory_managers.combat_manager.data;
+        ui.label("Encounter".to_string());
+        ui.label(format!(
+            "Encounter Active: {}",
+            combat_manager.encounter_active
+        ));
 
         ui.label("Level Info".to_string());
         ui.label(format!("Scene Name: {}", level_manager.scene_name));

--- a/src/memory/combat_manager.rs
+++ b/src/memory/combat_manager.rs
@@ -1,0 +1,52 @@
+use crate::memory::memory_context::MemoryContext;
+use crate::memory::{MemoryManager, MemoryManagerUpdate};
+use crate::state::StateContext;
+use log::info;
+use memory::memory_manager::il2cpp::UnityMemoryManager;
+use memory::process::MemoryError;
+
+impl Default for MemoryManager<CombatManagerData> {
+    fn default() -> Self {
+        let manager = Self {
+            name: "CombatManager".to_string(),
+            data: CombatManagerData::default(),
+            manager: UnityMemoryManager::default(),
+        };
+        info!("Memory: {} Loaded", manager.name);
+        manager
+    }
+}
+
+#[derive(Default, Debug)]
+pub struct CombatManagerData {
+    pub encounter_active: bool,
+}
+
+impl MemoryManagerUpdate for CombatManagerData {
+    fn update(
+        &mut self,
+        ctx: &StateContext,
+        manager: &mut UnityMemoryManager,
+    ) -> Result<(), MemoryError> {
+        let memory_context = MemoryContext::create(ctx, manager)?;
+
+        self.update_encounter_active(&memory_context)?;
+
+        Ok(())
+    }
+}
+
+impl CombatManagerData {
+    pub fn update_encounter_active(
+        &mut self,
+        memory_context: &MemoryContext,
+    ) -> Result<(), MemoryError> {
+        if let Ok(encounter_done) =
+            memory_context.follow_fields::<u8>(&["currentEncounter", "encounterDone"])
+        {
+            self.encounter_active = matches!(encounter_done, 0)
+        }
+
+        Ok(())
+    }
+}

--- a/src/memory/mod.rs
+++ b/src/memory/mod.rs
@@ -1,4 +1,5 @@
 pub mod boat_manager;
+pub mod combat_manager;
 pub mod currency_manager;
 pub mod cutscene_manager;
 pub mod level_manager;
@@ -15,6 +16,7 @@ use log::error;
 use crate::state::StateContext;
 
 use boat_manager::BoatManagerData;
+use combat_manager::CombatManagerData;
 use currency_manager::CurrencyManagerData;
 use cutscene_manager::CutsceneManagerData;
 use level_manager::LevelManagerData;
@@ -49,6 +51,7 @@ pub struct MemoryManagers {
     pub level_manager: MemoryManager<LevelManagerData>,
     pub currency_manager: MemoryManager<CurrencyManagerData>,
     pub new_dialog_manager: MemoryManager<NewDialogManagerData>,
+    pub combat_manager: MemoryManager<CombatManagerData>,
     pub cutscene_manager: MemoryManager<CutsceneManagerData>,
     pub shop_manager: MemoryManager<ShopManagerData>,
 }
@@ -63,6 +66,7 @@ impl MemoryManagers {
             self.level_manager.update(ctx);
             self.currency_manager.update(ctx);
             self.new_dialog_manager.update(ctx);
+            self.combat_manager.update(ctx);
             self.cutscene_manager.update(ctx);
             self.shop_manager.update(ctx);
         }


### PR DESCRIPTION
Quick MVP - heading out for a while

Instead of `encounter_done`, we're doing `encounter_active` so when defaults are loaded it will be `false` by default.

closes #71 