### PR TITLE
feat: persistence! including tabs!

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -230,6 +230,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
 name = "bincode"
 version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -290,6 +296,9 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bitvec"
@@ -700,6 +709,7 @@ dependencies = [
  "glow",
  "glutin",
  "glutin-winit",
+ "home",
  "image",
  "js-sys",
  "log",
@@ -709,6 +719,8 @@ dependencies = [
  "parking_lot",
  "percent-encoding",
  "raw-window-handle",
+ "ron",
+ "serde",
  "static_assertions",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -731,6 +743,7 @@ dependencies = [
  "epaint",
  "log",
  "nohash-hasher",
+ "ron",
  "serde",
 ]
 
@@ -745,6 +758,7 @@ dependencies = [
  "egui",
  "log",
  "raw-window-handle",
+ "serde",
  "smithay-clipboard",
  "web-time 1.1.0",
  "webbrowser",
@@ -760,6 +774,7 @@ dependencies = [
  "duplicate",
  "egui",
  "paste",
+ "serde",
 ]
 
 [[package]]
@@ -2260,6 +2275,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "ron"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b91f7eff05f748767f183df4320a63d6936e9c6107d97c9e6bdd9784f4289c94"
+dependencies = [
+ "base64",
+ "bitflags 2.6.0",
+ "serde",
+ "serde_derive",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,6 +2364,7 @@ dependencies = [
  "log",
  "memory",
  "puffin_egui",
+ "ron",
  "seq",
  "serde",
  "sysinfo",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,14 @@ data = { path = "crates/data", version = "0.1.0" }
 bytemuck = { version = "1.18.0", features = ["min_const_generics"] }
 seq = { path = "crates/seq", version = "0.1.0" }
 sysinfo = { version = "0.32.0", default-features = false, features = ["system", "multithread"] }
-egui = "0.29"
+egui = { version = "0.29", features = ["persistence"] }
 serde = { version = "1.0", features = ["derive"] }
 eframe = { version = "0.29", default-features = false, features = [
     "default_fonts", # Embed the default egui fonts.
     "glow",          # Use the glow rendering backend. Alternative: "wgpu".
-    # "persistence",   # Enable restoring app state when restarting the app.
+    "persistence",   # Enable restoring app state when restarting the app.
 ] }
-egui_dock = "0.14.0"
+egui_dock = { version = "0.14.0", features = ["serde"] }
 colog = "1.3.0"
 log = "0.4.22"
 puffin_egui = { git = "https://github.com/tedsteen/puffin", branch = "upgrade-egui" }
@@ -30,6 +30,7 @@ itoa = "1.0.11"
 delta = "0.2.1"
 itertools = "0.13.0"
 fps_clock = "2.0.0"
+ron = "0.8.1"
 
 [dependencies.winit]
 # version = "*"

--- a/config.toml.example
+++ b/config.toml.example
@@ -2,6 +2,9 @@
 # Examples on serialization and deserialization here:
 # https://docs.rs/toml/latest/toml/#deserialization-and-serialization
 
+# Do tabs persist between restarts
+persist_tab_state = true
+
 # Speedrun related parameters
 konami_code = true
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -32,6 +32,7 @@ pub const RELIC_NAMES: [&str; 21] = [
 
 #[derive(Deserialize, Default, Debug)]
 pub struct Config {
+    pub persist_tab_state: bool,
     pub konami_code: bool,
     pub relics: HashMap<String, bool>,
 }

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -33,6 +33,7 @@ impl egui_dock::TabViewer for TabViewer<'_> {
 impl Gui {
     pub fn run(conf: Config) {
         let options = eframe::NativeOptions {
+            persist_window: true,
             viewport: egui::ViewportBuilder::default()
                 .with_inner_size([800.0, 800.0])
                 .with_min_inner_size([800.0, 800.0]),


### PR DESCRIPTION
- adds persistence to egui app. This stores all scrollbars and CollapsingHeader state (open/close)
- adds persistence for tab layout!
- adds a config option for this, this will be helpful for developing a 'default layout' later, and can be removed at that time.

Storage is `ron` and is saved per https://docs.rs/eframe/latest/eframe/fn.storage_dir.html

```
On native, the path is:

    Linux: /home/UserName/.local/share/APP_ID
    macOS: /Users/UserName/Library/Application Support/APP_ID
    Windows: C:\Users\UserName\AppData\Roaming\APP_ID\data
```

We may be able to modify the `APP_ID`, but for now by default its `seaofstarstas`