### PR TITLE
fix: safely exit on inventory manager failure

### DIFF
--- a/src/memory/inventory_manager.rs
+++ b/src/memory/inventory_manager.rs
@@ -59,11 +59,13 @@ impl InventoryManagerData {
         // If currentInventory != 0x0
         if let Ok(items_ptr) = memory_context.follow_fields::<u64>(&["ownedInventoryItems"]) {
             if items_ptr != 0x0 {
-                self.items =
-                    UnitySerializableDictionary::<InventoryItemName, InventoryItemQuantity>::read(
-                        memory_context.process,
-                        items_ptr,
-                    )?;
+                if let Ok(items) = UnitySerializableDictionary::<
+                    InventoryItemName,
+                    InventoryItemQuantity,
+                >::read(memory_context.process, items_ptr)
+                {
+                    self.items = items
+                };
             }
         }
 


### PR DESCRIPTION
Fixes a memory manager error causes by a `?` at higher up. 

we now use an `if let` here