### PR TITLE
feat: adds additional enemy fields

### DIFF
--- a/src/gui/helpers/combat_helper.rs
+++ b/src/gui/helpers/combat_helper.rs
@@ -81,13 +81,13 @@ impl GuiHelper for CombatHelper {
                         ui.label(format!("{}", enemy.turns_to_action));
                         ui.label(format!("{}", enemy.total_spell_locks));
 
-                        let mut lock_str = String::from("");
+                        let mut lock_str = String::new();
                         for lock in enemy.spell_locks.items.iter() {
                             lock_str = format!("{} {:?}", &lock_str, &lock);
                         }
                         ui.label(lock_str);
 
-                        let mut damage_modifiers_str = String::from("");
+                        let mut damage_modifiers_str = String::new();
                         for modifier in enemy.damage_type_modifiers.items.iter() {
                             damage_modifiers_str = format!(
                                 "{} {:?} {}",
@@ -96,7 +96,7 @@ impl GuiHelper for CombatHelper {
                         }
                         ui.label(damage_modifiers_str);
 
-                        let mut damage_modifiers_override_str = String::from("");
+                        let mut damage_modifiers_override_str = String::new();
                         for modifier in enemy.damage_type_modifiers_override.items.iter() {
                             damage_modifiers_override_str = format!(
                                 "{} {:?} {}",

--- a/src/gui/helpers/combat_helper.rs
+++ b/src/gui/helpers/combat_helper.rs
@@ -48,6 +48,7 @@ impl GuiHelper for CombatHelper {
                 .striped(true)
                 .show(ui, |ui| {
                     ui.label("Name");
+                    ui.label("Lv");
                     ui.label("Guid");
                     ui.label("Uuid");
                     ui.label("HP");
@@ -59,10 +60,16 @@ impl GuiHelper for CombatHelper {
                     ui.label("Act");
                     ui.label("#");
                     ui.label("Locks");
+                    ui.label("Mod");
+                    ui.label("ModOverride");
+                    ui.label("Fleshmancer");
+                    ui.label("ManaSpnQty");
+
                     ui.end_row();
 
                     for (i, enemy) in combat_manager.enemies.items.iter().enumerate() {
                         ui.label(format!("NYI ({})", i));
+                        ui.label(format!("{}", enemy.level));
                         ui.label(format!("{:.5}", enemy.guid));
                         ui.label(format!("{:.5}", enemy.unique_id));
                         ui.label(format!("{}/{}", enemy.current_hp, enemy.max_hp));
@@ -73,9 +80,33 @@ impl GuiHelper for CombatHelper {
                         ui.label(format!("{}", enemy.magical_defense));
                         ui.label(format!("{}", enemy.turns_to_action));
                         ui.label(format!("{}", enemy.total_spell_locks));
+
+                        let mut lock_str = String::from("");
                         for lock in enemy.spell_locks.items.iter() {
-                            ui.label(format!("{:?}", lock));
+                            lock_str = format!("{} {:?}", &lock_str, &lock);
                         }
+                        ui.label(lock_str);
+
+                        let mut damage_modifiers_str = String::from("");
+                        for modifier in enemy.damage_type_modifiers.items.iter() {
+                            damage_modifiers_str = format!(
+                                "{} {:?} {}",
+                                damage_modifiers_str, modifier.0.key, modifier.1.value
+                            );
+                        }
+                        ui.label(damage_modifiers_str);
+
+                        let mut damage_modifiers_override_str = String::from("");
+                        for modifier in enemy.damage_type_modifiers_override.items.iter() {
+                            damage_modifiers_override_str = format!(
+                                "{} {:?} {}",
+                                damage_modifiers_override_str, modifier.0.key, modifier.1.value
+                            );
+                        }
+                        ui.label(damage_modifiers_override_str);
+                        ui.label(format!("{}", enemy.fleshmancer_minion));
+                        ui.label(format!("{}", enemy.live_mana_spawn_quantity));
+
                         ui.end_row();
                     }
                 });

--- a/src/memory/inventory_manager.rs
+++ b/src/memory/inventory_manager.rs
@@ -88,7 +88,7 @@ pub struct InventoryItemQuantity(pub u64);
 
 impl UnitySerializableDictKey for InventoryItemName {
     fn read(process: &Process, item_ptr: u64) -> Result<Self, MemoryError> {
-        if let Ok(guid) = process.read::<ArrayWString<128>>(item_ptr + 0x14) {
+        if let Ok(guid) = process.read_pointer_path::<ArrayWString<128>>(item_ptr, &[0x0, 0x14]) {
             match String::from_utf16(guid.as_slice()) {
                 Ok(value) => match all_items().get(value.as_str()) {
                     Some(item) => Ok(InventoryItemName(item.name.to_string())),
@@ -103,8 +103,11 @@ impl UnitySerializableDictKey for InventoryItemName {
 }
 
 impl UnitySerializableDictValue for InventoryItemQuantity {
-    fn read(_process: &Process, item_ptr: u64) -> Result<Self, MemoryError> {
-        // For this, the value is simply stored at the pointer
-        Ok(InventoryItemQuantity(item_ptr))
+    fn read(process: &Process, item_ptr: u64) -> Result<Self, MemoryError> {
+        if let Ok(value) = process.read_pointer_path::<u64>(item_ptr, &[0x0]) {
+            Ok(InventoryItemQuantity(value))
+        } else {
+            Err(MemoryError::ReadError)
+        }
     }
 }


### PR DESCRIPTION
This PR Adds:
- updates to unity serializeable dict
  - adds safety on intiial read addr being 0x0
  - makes the dict implementation only get the pointer path without reading it, as some reads may not follow a pointer - leaves that to the implementor
- adds the following to combat enemy
  - fleshmancer minion
  - live mana spawn quantity
  - damage modifiers
  - damage modifiers override (unchecked)
- implements inventory manager with the serializable dict changes

On L#103 i still have to use tuple syntax for KV due to to the way IndexMaps work. Unfortunate.
