### PR TITLE
feat: use descriptions for checkpoints and clean up selection box

### DIFF
--- a/src/gui/helpers/main_helper.rs
+++ b/src/gui/helpers/main_helper.rs
@@ -35,40 +35,28 @@ impl GuiHelper for MainHelper {
         }
 
         egui::ComboBox::from_label("Checkpoint")
-            .selected_text(format!("{:?}", self.checkpoint))
+            .selected_text(
+                self.checkpoint
+                    .clone()
+                    .unwrap_or(String::from("New Game"))
+                    .to_string(),
+            )
             .show_ui(ui, |ui| {
-                ui.selectable_value(&mut self.checkpoint, None, "New Game");
-                ui.selectable_value(
-                    &mut self.checkpoint,
-                    Some("intro_mooncradle".to_owned()),
+                for checkpoint in [
+                    "New Game",
                     "Mooncradle Intro Cavern",
-                );
-                ui.selectable_value(
-                    &mut self.checkpoint,
-                    Some("intro_dorms".to_owned()),
                     "Zenith Academy Dorms",
-                );
-                ui.selectable_value(
-                    &mut self.checkpoint,
-                    Some("intro_dorms2".to_owned()),
                     "Zenith Academy Dorms 2",
-                );
-                ui.selectable_value(
-                    &mut self.checkpoint,
-                    Some("forbidden_cave".to_owned()),
                     "Outside Forbidden Cavern",
-                );
-                ui.selectable_value(
-                    &mut self.checkpoint,
-                    Some("forbidden_cave2".to_owned()),
                     "Before Bosslug",
-                );
-                // TODO: More checkpoints
-                ui.selectable_value(
-                    &mut self.checkpoint,
-                    Some("elder_mist_boss2".to_owned()),
                     "After Elder Mist Boss-fight",
-                );
+                ] {
+                    ui.selectable_value(
+                        &mut self.checkpoint,
+                        Some(checkpoint.to_string()),
+                        checkpoint,
+                    );
+                }
             });
 
         if ui

--- a/src/route/evermist_island/elder_mist.rs
+++ b/src/route/evermist_island/elder_mist.rs
@@ -10,7 +10,7 @@ pub fn create() -> Box<dyn Node<GameState, GameEvent>> {
         "Elder Mist",
         vec![
             // TODO: more stuff
-            SeqCheckpoint::create("elder_mist_boss2"),
+            SeqCheckpoint::create("After Elder Mist Boss-fight"),
             SeqMove::create(
                 "Leave dream world",
                 vec![

--- a/src/route/evermist_island/forbidden_cave.rs
+++ b/src/route/evermist_island/forbidden_cave.rs
@@ -127,7 +127,7 @@ pub fn create() -> Box<dyn Node<GameState, GameEvent>> {
                     Move::Confirm,
                 ],
             ),
-            SeqCheckpoint::create("forbidden_cave2"),
+            SeqCheckpoint::create("Before Bosslug"),
             // Continue to boss
             SeqMove::create(
                 "Boss",

--- a/src/route/evermist_island/mod.rs
+++ b/src/route/evermist_island/mod.rs
@@ -29,7 +29,7 @@ pub fn create() -> Box<dyn Node<GameState, GameEvent>> {
                 Some(mooncradle::flashback()),
                 false,
             ),
-            SeqCheckpoint::create("forbidden_cave"),
+            SeqCheckpoint::create("Outside Forbidden Cavern"),
             forbidden_cave::create(),
             // TODO: Rest of mountain trail
             SeqLog::create("TODO BREAK"),

--- a/src/route/evermist_island/mooncradle.rs
+++ b/src/route/evermist_island/mooncradle.rs
@@ -37,7 +37,7 @@ pub fn flashback() -> Box<dyn Node<GameState, GameEvent>> {
     SeqList::create(
         "Mooncradle flashback",
         vec![
-            SeqCheckpoint::create("intro_mooncradle"),
+            SeqCheckpoint::create("Mooncradle Intro Cavern"),
             SeqMove::create(
                 "Mooncradle intro",
                 vec![
@@ -81,7 +81,7 @@ pub fn flashback() -> Box<dyn Node<GameState, GameEvent>> {
                     Move::To(94.005, -11.998, -133.576),
                 ],
             ),
-            SeqCheckpoint::create("intro_dorms"),
+            SeqCheckpoint::create("Zenith Academy Dorms"),
             SeqIf::create(
                 "MC Valere",
                 CondMainChar {
@@ -183,7 +183,7 @@ pub fn flashback() -> Box<dyn Node<GameState, GameEvent>> {
                 ],
             ),
             looms_to_center(),
-            SeqCheckpoint::create("intro_dorms2"),
+            SeqCheckpoint::create("Zenith Academy Dorms 2"),
             SeqMove::create(
                 "Move to Moraine",
                 vec![


### PR DESCRIPTION
Take a look at `main_helper.rs` directly, the diff is really noisy.

This uses normal descriptions for checkpoints and updates the combobox in main_helper to use these strings.

Turns out an invalid string just starts from scratch, so adding "New Game" to the list doesn't change anything. (Assuming this is intended :))

closes #105
