### PR TITLE
feat: add active to title seq manager

### DIFF
--- a/crates/memory/src/memory_manager/il2cpp.rs
+++ b/crates/memory/src/memory_manager/il2cpp.rs
@@ -37,6 +37,8 @@ impl UnityMemoryManagement for UnityMemoryManager {
             if let Some(static_table) = self.static_table {
                 if let Ok(addr) = process.read_pointer::<u64>(static_table + instance as u64) {
                     self.singleton = Some(Class { class: addr });
+                } else {
+                    self.singleton = Some(Class { class: 0 });
                 }
             }
         }

--- a/src/memory/title_sequence_manager.rs
+++ b/src/memory/title_sequence_manager.rs
@@ -13,6 +13,8 @@ use memory::string::{ArrayCString, ArrayWString};
 
 #[derive(Default, Debug)]
 pub struct TitleSequenceManagerData {
+    /// True if singleton is not 0x0
+    pub active: bool,
     /// Title Menu Option data
     pub title_menu_option_selected: TitleMenuOption,
     /// Current Screen Name field
@@ -46,6 +48,9 @@ impl MemoryManagerUpdate for TitleSequenceManagerData {
         manager: &mut UnityMemoryManager,
     ) -> Result<(), MemoryError> {
         let memory_context = MemoryContext::create(ctx, manager)?;
+
+        // if the singleton is not 0x0, set active true
+        self.active = !matches!(memory_context.singleton.class, 0);
 
         self.update_pressed_start(&memory_context)?;
         self.update_current_screen_name(&memory_context)?;


### PR DESCRIPTION
This PR Adds

- setting singleton to 0 if it cant be read. this will be useful down the road if we need more controller active checks
- check singleton.class on title sequence manager - and sets self.active to true or false for GUI

In the future, we will set this value on all managers for use under self.active (if singleton == 0x0) that way we can avoid updates the the controller entirely if no manager exists in ready for update. 

Currently it checks and fails silently while unwrapping manager internals. (minor perf improvement.)