### PR TITLE
fix: only render locks if turns to action > 0

### DIFF
--- a/src/gui/helpers/main_helper.rs
+++ b/src/gui/helpers/main_helper.rs
@@ -144,8 +144,10 @@ impl MainHelper {
                             ui.label(format!("{}", enemy.total_spell_locks));
 
                             ui.horizontal(|ui| {
-                                for modifier in enemy.spell_locks.items.iter() {
-                                    damage_type_image(ui, modifier)
+                                if enemy.turns_to_action > 0 {
+                                    for modifier in enemy.spell_locks.items.iter() {
+                                        damage_type_image(ui, modifier)
+                                    }
                                 }
                                 // This is required to push the column that images dont seem to resize
                                 ui.label("");


### PR DESCRIPTION
closes #130

Not too worried about checking total spell locks here like the python tas, as the loop will just do nothing