### PR TITLE
feat: adds difficulty selection

### DIFF
--- a/src/gui/helpers/main_helper.rs
+++ b/src/gui/helpers/main_helper.rs
@@ -53,6 +53,10 @@ impl MainHelper {
 
         ui.label("Title Screen Active");
         match tsmd.current_screen_name.as_str() {
+            "DifficultySelection" => {
+                ui.label("Difficulty Selection");
+                ui.label(format!("Selected: {:?}", tsmd.selected_difficulty));
+            }
             "TitleScreen" => {
                 if tsmd.pressed_start {
                     ui.label(format!(

--- a/src/memory/title_sequence_manager.rs
+++ b/src/memory/title_sequence_manager.rs
@@ -13,9 +13,9 @@ use memory::string::{ArrayCString, ArrayWString};
 
 #[derive(Default, Debug)]
 pub enum Difficulty {
-    Easy,
-    Normal,
-    Hard,
+    Story,
+    Adventure,
+    Challenge,
     #[default]
     None,
 }
@@ -184,9 +184,9 @@ impl TitleSequenceManagerData {
                 .follow_fields::<u8>(&["difficultySelectionScreen", "selectedDifficulty"])
             {
                 self.selected_difficulty = match selected_difficulty {
-                    2 => Difficulty::Easy,
-                    4 => Difficulty::Normal,
-                    8 => Difficulty::Hard,
+                    2 => Difficulty::Story,
+                    4 => Difficulty::Adventure,
+                    8 => Difficulty::Challenge,
                     _ => Difficulty::None,
                 };
             }

--- a/src/memory/title_sequence_manager.rs
+++ b/src/memory/title_sequence_manager.rs
@@ -12,6 +12,15 @@ use memory::process::Process;
 use memory::string::{ArrayCString, ArrayWString};
 
 #[derive(Default, Debug)]
+pub enum Difficulty {
+    Easy,
+    Normal,
+    Hard,
+    #[default]
+    None,
+}
+
+#[derive(Default, Debug)]
 pub struct TitleSequenceManagerData {
     /// True if singleton is not 0x0
     pub active: bool,
@@ -27,6 +36,8 @@ pub struct TitleSequenceManagerData {
     pub load_save_done: bool,
     /// If the player has pressed start on the intro screen.
     pub pressed_start: bool,
+    /// The selected difficulty - only when the screen is active or else None
+    pub selected_difficulty: Difficulty,
 }
 
 impl Default for MemoryManager<TitleSequenceManagerData> {
@@ -58,6 +69,10 @@ impl MemoryManagerUpdate for TitleSequenceManagerData {
         if self.pressed_start && self.current_screen_name == "TitleScreen" {
             self.update_load_save_done(&memory_context)?;
             self.update_title_menu(&memory_context)?;
+        }
+
+        if self.current_screen_name == "DifficultySelection" {
+            self.update_difficulty_selection(&memory_context)?;
         }
 
         if self.current_screen_name == "RelicSelection" {
@@ -151,6 +166,30 @@ impl TitleSequenceManagerData {
             == Some(1)
         {
             self.title_menu_option_selected = TitleMenuOption::QuitGame
+        }
+        Ok(())
+    }
+
+    pub fn update_difficulty_selection(
+        &mut self,
+        memory_context: &MemoryContext,
+    ) -> Result<(), MemoryError> {
+        if let Ok(active) =
+            memory_context.follow_fields::<u8>(&["difficultySelectionScreen", "active"])
+        {
+            if active != 1 {
+                self.selected_difficulty = Difficulty::None;
+                return Ok(());
+            } else if let Ok(selected_difficulty) = memory_context
+                .follow_fields::<u8>(&["difficultySelectionScreen", "selectedDifficulty"])
+            {
+                self.selected_difficulty = match selected_difficulty {
+                    2 => Difficulty::Easy,
+                    4 => Difficulty::Normal,
+                    8 => Difficulty::Hard,
+                    _ => Difficulty::None,
+                };
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
Adds difficulty selection screen info/helper

It checks the `difficultySelectionScreen` object on title sequence manager:

- `active` on this object only sets to `1` when you can actually act on the screen
- `Difficulty::None` will be set unless you are active

If the active field is actually needed to accomplish integration let me know; simple change.

This will always be `Difficulty::None` when this screen is visible unless `selectedDifficulty` field is set to something else.

In the code its: Easy, Normal, Hard - but i've updated the enum to be Story, Adventure, Challenge for parity.

closes #136