### PR TITLE
Feat/difficulty

### DIFF
--- a/config.toml.example
+++ b/config.toml.example
@@ -9,15 +9,19 @@ persist_tab_state = true
 konami_code = true
 
 [relics]
-"Solstice Diploma" = false
+"Solstice Diploma" = true
 "Amulet of Storytelling" = true
+"Tourist's Provision" = true
+"Volitional Spirit" = true
+"Signifying Glass" = false
 "Guardian Aura" = true
-"Sequent Flare" = false
-"Truestrike Pendant" = false
-"Tome of Knowledge" = false
+"Sequent Flare" = true
+"Truestrike Pendant" = true
+"Tome of Knowledge" = true
 "Falcon-eyed Parrot" = false
 "Salient Sails" = false
 "Gold Tooth" = false
+"Chef's Knife" = false
 "Sixth Sense" = false
 "Adamant Shard" = false
 "Hidden Pockets" = false

--- a/src/gui/helpers/main_helper.rs
+++ b/src/gui/helpers/main_helper.rs
@@ -55,7 +55,11 @@ impl MainHelper {
         match tsmd.current_screen_name.as_str() {
             "DifficultySelection" => {
                 ui.label("Difficulty Selection");
-                ui.label(format!("Selected: {:?}", tsmd.selected_difficulty));
+                if let Some(difficulty) = &tsmd.selected_difficulty {
+                    ui.label(format!("Selected: {:?}", difficulty));
+                } else {
+                    ui.label("Screen inactive");
+                }
             }
             "TitleScreen" => {
                 if tsmd.pressed_start {

--- a/src/memory/title_sequence_manager.rs
+++ b/src/memory/title_sequence_manager.rs
@@ -17,7 +17,7 @@ pub enum Difficulty {
     Adventure,
     Challenge,
     #[default]
-    None,
+    NoSelection,
 }
 
 #[derive(Default, Debug)]
@@ -37,7 +37,7 @@ pub struct TitleSequenceManagerData {
     /// If the player has pressed start on the intro screen.
     pub pressed_start: bool,
     /// The selected difficulty - only when the screen is active or else None
-    pub selected_difficulty: Difficulty,
+    pub selected_difficulty: Option<Difficulty>,
 }
 
 impl Default for MemoryManager<TitleSequenceManagerData> {
@@ -178,16 +178,16 @@ impl TitleSequenceManagerData {
             memory_context.follow_fields::<u8>(&["difficultySelectionScreen", "active"])
         {
             if active != 1 {
-                self.selected_difficulty = Difficulty::None;
+                self.selected_difficulty = None;
                 return Ok(());
             } else if let Ok(selected_difficulty) = memory_context
                 .follow_fields::<u8>(&["difficultySelectionScreen", "selectedDifficulty"])
             {
                 self.selected_difficulty = match selected_difficulty {
-                    2 => Difficulty::Story,
-                    4 => Difficulty::Adventure,
-                    8 => Difficulty::Challenge,
-                    _ => Difficulty::None,
+                    2 => Some(Difficulty::Story),
+                    4 => Some(Difficulty::Adventure),
+                    8 => Some(Difficulty::Challenge),
+                    _ => Some(Difficulty::NoSelection),
                 };
             }
         }

--- a/src/route/tas.rs
+++ b/src/route/tas.rs
@@ -1,7 +1,7 @@
 use seq::prelude::*;
 
 use crate::game_manager::GameManager;
-// use crate::seq::relics::SeqRelicList;
+use crate::seq::relics::SeqRelicList;
 use crate::seq::title::SeqTitleScreen;
 
 use super::evermist_island;
@@ -13,7 +13,7 @@ pub fn create_tas() -> GameManager {
         vec![
             SeqLog::create("SEQ START"),
             SeqTitleScreen::create(),
-            // SeqRelicList::create(),
+            SeqRelicList::create(),
             evermist_island::create(),
             sleeper_island::create(),
             SeqLog::create("SEQ DONE"),

--- a/src/seq/relics.rs
+++ b/src/seq/relics.rs
@@ -12,6 +12,7 @@ use crate::seq::button::ButtonPress;
 #[derive(Default, Debug)]
 enum RelicScreenFSM {
     #[default]
+    WaitOnScreen,
     Eval,
     PressButton,
 }
@@ -26,7 +27,6 @@ pub struct SeqRelicList {
 }
 
 impl SeqRelicList {
-    #[allow(dead_code)]
     pub fn create() -> Box<Self> {
         Box::new(Self::default())
     }
@@ -57,6 +57,15 @@ impl SeqRelicList {
             action: SosAction::Confirm,
             press_time: 0.1,
             release_time: 0.1,
+            ..Default::default()
+        };
+    }
+
+    // Open the relics menu from the difficulty screen
+    fn open_relics(&mut self) {
+        self.fsm = RelicScreenFSM::PressButton;
+        self.btn = ButtonPress {
+            action: SosAction::Menu,
             ..Default::default()
         };
     }
@@ -104,6 +113,13 @@ impl Node<GameState, GameEvent> for SeqRelicList {
         let tsmd = &state.memory_managers.title_sequence_manager.data;
 
         match self.fsm {
+            RelicScreenFSM::WaitOnScreen => {
+                // Wait until difficulty selection screen is active
+                if tsmd.selected_difficulty.is_some() {
+                    // Note, actual difficulty selection not needed if we are doing relics
+                    self.open_relics();
+                }
+            }
             RelicScreenFSM::Eval => {
                 // Check if we can get the currently selected relic
                 if let Some(cur_relic) = self.get_current_relic(tsmd) {


### PR DESCRIPTION
Reactivates the relic selection screen and integrates the new difficulty selection (currently doesn't use the presets).

Also adds the new relics that were added in the update to the default config.