### PR TITLE
feat: adds interacting characters and quick debug view

### DIFF
--- a/src/gui/helpers/debug_helper.rs
+++ b/src/gui/helpers/debug_helper.rs
@@ -128,6 +128,17 @@ impl GuiHelper for DebugHelper {
 
         ui.separator();
         ui.label("SPP Manager");
+        ui.label("Interacting Characters");
+        let interacting_characters = sppmd.interacting_characters.clone();
+        if interacting_characters.is_empty() {
+            ui.label("None");
+        } else {
+            for player in sppmd.interacting_characters.clone() {
+                ui.label(format!("{:?}", player));
+            }
+        }
+
+        ui.separator();
         for (idx, player) in sppmd.players.items.iter().enumerate() {
             ui.label(format!("Name: {}", player.name));
             ui.label(format!("Character: {:?}", player.character));

--- a/src/memory/single_player_plus_manager.rs
+++ b/src/memory/single_player_plus_manager.rs
@@ -30,6 +30,7 @@ pub struct Player {
 
 #[derive(Default, Debug)]
 pub struct SinglePlayerPlusManagerData {
+    pub interacting_characters: Vec<PlayerPartyCharacter>,
     pub players: UnityList<Player>,
 }
 
@@ -54,12 +55,33 @@ impl MemoryManagerUpdate for SinglePlayerPlusManagerData {
         let memory_context = MemoryContext::create(ctx, manager)?;
 
         self.update_players(&memory_context)?;
+        self.update_interacting_characters(&memory_context)?;
 
         Ok(())
     }
 }
 
 impl SinglePlayerPlusManagerData {
+    pub fn update_interacting_characters(
+        &mut self,
+        _memory_context: &MemoryContext,
+    ) -> Result<(), MemoryError> {
+        let mut interacting_characters = vec![];
+        for player in &self.players.items {
+            match player.state.as_str() {
+                "SinglePlayerPlusInteractState" => {
+                    interacting_characters.push(player.character.clone())
+                }
+                "PressurePlateSinglePlayerPlusInteractState" => {
+                    interacting_characters.push(player.character.clone())
+                }
+                _ => (),
+            }
+        }
+        self.interacting_characters = interacting_characters;
+
+        Ok(())
+    }
     pub fn update_players(&mut self, memory_context: &MemoryContext) -> Result<(), MemoryError> {
         if let Ok(players) = memory_context.follow_fields::<u64>(&["allPlayers"]) {
             let players = UnityList::<Player>::read(memory_context.process, players)?;


### PR DESCRIPTION
closes #149 

Adds a quick interacting character list and debug helper view for them.

From initial look, it will show if a character is interacting, but as soon as the interaction state no longer applies, it will return to `None`

`PressurePlateSinglePlayerPlusInteractState` was the only additional derived class from the `SinglePlayerPlusInteractState` but there could be others we may find useful - this is all i could find at the moment though.